### PR TITLE
Add DoAsync extension method (sync and async overloads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,60 @@ await foreach (var batch in numbers.ChunkAsync(50))
 }
 ```
 
+#### **`DoAsync<T>` (Synchronous action)**
+Executes a synchronous side-effect action on each element without transforming the elements. The original items are yielded unchanged.
+
+```csharp
+public static async IAsyncEnumerable<T> DoAsync<T>(
+    this IAsyncEnumerable<T> source,
+    Action<T> action,
+    CancellationToken token = default)
+```
+
+**Parameters:**
+- `source` - The source async enumerable
+- `action` - The synchronous action to execute on each element
+- `token` - Optional cancellation token
+
+**Returns:** An async enumerable that yields the original elements after executing the action.
+
+**Example:**
+```csharp
+var numbers = GetAsyncNumbers(); // IAsyncEnumerable<int>
+await foreach (var item in numbers.DoAsync(x => Console.WriteLine($"Processing: {x}")))
+{
+    // item is unchanged — DoAsync is a pass-through
+}
+```
+
+#### **`DoAsync<T>` (Asynchronous action)**
+Executes an asynchronous side-effect action on each element without transforming the elements.
+
+```csharp
+public static async IAsyncEnumerable<T> DoAsync<T>(
+    this IAsyncEnumerable<T> source,
+    Func<T, Task> action,
+    CancellationToken token = default)
+```
+
+**Parameters:**
+- `source` - The source async enumerable
+- `action` - The asynchronous action to execute on each element
+- `token` - Optional cancellation token
+
+**Returns:** An async enumerable that yields the original elements after executing the action.
+
+**Example:**
+```csharp
+// Chain DoAsync with other extensions for logging/metrics in a pipeline
+await foreach (var batch in source
+    .DoAsync(async x => await logger.LogAsync($"Processing: {x}"))
+    .ChunkAsync(100))
+{
+    await ProcessBatchAsync(batch);
+}
+```
+
 ---
 
 ## 🎯 Target Frameworks

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -68,6 +68,60 @@ await foreach (var batch in numbers.ChunkAsync(50))
 }
 ```
 
+#### **`DoAsync<T>` (Synchronous action)**
+Executes a synchronous side-effect action on each element without transforming the elements. The original items are yielded unchanged.
+
+```csharp
+public static async IAsyncEnumerable<T> DoAsync<T>(
+    this IAsyncEnumerable<T> source,
+    Action<T> action,
+    CancellationToken token = default)
+```
+
+**Parameters:**
+- `source` - The source async enumerable
+- `action` - The synchronous action to execute on each element
+- `token` - Optional cancellation token
+
+**Returns:** An async enumerable that yields the original elements after executing the action.
+
+**Example:**
+```csharp
+var numbers = GetAsyncNumbers(); // IAsyncEnumerable<int>
+await foreach (var item in numbers.DoAsync(x => Console.WriteLine($"Processing: {x}")))
+{
+    // item is unchanged — DoAsync is a pass-through
+}
+```
+
+#### **`DoAsync<T>` (Asynchronous action)**
+Executes an asynchronous side-effect action on each element without transforming the elements.
+
+```csharp
+public static async IAsyncEnumerable<T> DoAsync<T>(
+    this IAsyncEnumerable<T> source,
+    Func<T, Task> action,
+    CancellationToken token = default)
+```
+
+**Parameters:**
+- `source` - The source async enumerable
+- `action` - The asynchronous action to execute on each element
+- `token` - Optional cancellation token
+
+**Returns:** An async enumerable that yields the original elements after executing the action.
+
+**Example:**
+```csharp
+// Chain DoAsync with other extensions for logging/metrics in a pipeline
+await foreach (var batch in source
+    .DoAsync(async x => await logger.LogAsync($"Processing: {x}"))
+    .ChunkAsync(100))
+{
+    await ProcessBatchAsync(batch);
+}
+```
+
 ---
 
 ## 🎯 Target Frameworks

--- a/src/Wolfgang.Extensions.IAsyncEnumerable/IAsyncEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/IAsyncEnumerableExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 [assembly: InternalsVisibleTo("Wolfgang.Extensions.IAsyncEnumerable.Benchmarks")]
 [assembly: InternalsVisibleTo("Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit")]
@@ -23,8 +24,8 @@ public static class IAsyncEnumerableExtensions
     /// <param name="token">A cancellation token to cancel the operation.</param>
     /// <typeparam name="T">The type of elements in the IAsyncEnumerable{T}.</typeparam>
     /// <returns>An IAsyncEnumerable{ICollection{T}} representing the chunks.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when source is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when maxChunkSize is less than one.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxChunkSize"/> is less than one.</exception>
     public static async IAsyncEnumerable<ICollection<T>> ChunkAsync<T>
     (
         this IAsyncEnumerable<T> source,
@@ -75,5 +76,103 @@ public static class IAsyncEnumerableExtensions
 
         Array.Resize(ref array, index);
         yield return array;
+    }
+
+
+
+    /// <summary>
+    /// Executes a synchronous side-effect action on each element of an IAsyncEnumerable{T}
+    /// without transforming the elements. The original items are yielded unchanged.
+    /// </summary>
+    /// <param name="source">The source IAsyncEnumerable{T}.</param>
+    /// <param name="action">The synchronous action to execute on each element.</param>
+    /// <param name="token">A cancellation token to cancel the operation.</param>
+    /// <typeparam name="T">The type of elements in the IAsyncEnumerable{T}.</typeparam>
+    /// <returns>An IAsyncEnumerable{T} that yields the original elements after executing the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="action"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// await foreach (var item in source.DoAsync(x => Console.WriteLine($"Processing: {x}")))
+    /// {
+    ///     // item is unchanged
+    /// }
+    /// </code>
+    /// </example>
+    public static async IAsyncEnumerable<T> DoAsync<T>
+    (
+        this IAsyncEnumerable<T> source,
+        Action<T> action,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        await using var enumerator = source.GetAsyncEnumerator(token);
+
+        while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+        {
+            action(enumerator.Current);
+            yield return enumerator.Current;
+            token.ThrowIfCancellationRequested();
+        }
+    }
+
+
+
+    /// <summary>
+    /// Executes an asynchronous side-effect action on each element of an IAsyncEnumerable{T}
+    /// without transforming the elements. The original items are yielded unchanged.
+    /// </summary>
+    /// <param name="source">The source IAsyncEnumerable{T}.</param>
+    /// <param name="action">The asynchronous action to execute on each element.</param>
+    /// <param name="token">A cancellation token to cancel the operation.</param>
+    /// <typeparam name="T">The type of elements in the IAsyncEnumerable{T}.</typeparam>
+    /// <returns>An IAsyncEnumerable{T} that yields the original elements after executing the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> or <paramref name="action"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// await foreach (var item in source.DoAsync(async x => await logger.LogAsync($"Processing: {x}")))
+    /// {
+    ///     // item is unchanged
+    /// }
+    /// </code>
+    /// </example>
+    public static async IAsyncEnumerable<T> DoAsync<T>
+    (
+        this IAsyncEnumerable<T> source,
+        Func<T, Task> action,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        await using var enumerator = source.GetAsyncEnumerator(token);
+
+        while (await enumerator.MoveNextAsync().ConfigureAwait(false))
+        {
+            await action(enumerator.Current).ConfigureAwait(false);
+            yield return enumerator.Current;
+            token.ThrowIfCancellationRequested();
+        }
     }
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DoAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DoAsyncTests.cs
@@ -1,0 +1,454 @@
+namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+
+public sealed class DoAsyncTests
+{
+    [Fact]
+    public async Task DoAsync_Action_when_source_has_items_executes_action_on_each()
+    {
+        var source = CreateSource(1, 2, 3);
+        var observed = new List<int>();
+
+        var result = await CollectAsync(source.DoAsync(x => observed.Add(x)));
+
+        Assert.Equal([1, 2, 3], observed);
+        Assert.Equal([1, 2, 3], result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_when_source_is_empty_executes_no_actions()
+    {
+        var source = CreateSource();
+        var observed = new List<int>();
+
+        var result = await CollectAsync(source.DoAsync(x => observed.Add(x)));
+
+        Assert.Empty(observed);
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_when_source_is_null_throws_ArgumentNullException()
+    {
+        IAsyncEnumerable<int> source = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>
+        (
+            () => CollectAsync(source.DoAsync(_ => { }))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_when_action_is_null_throws_ArgumentNullException()
+    {
+        var source = CreateSource(1, 2, 3);
+
+        await Assert.ThrowsAsync<ArgumentNullException>
+        (
+            () => CollectAsync(source.DoAsync((Action<int>)null!))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_yields_original_items_unchanged()
+    {
+        var source = CreateSource(10, 20, 30);
+
+        var result = await CollectAsync(source.DoAsync(_ => { }));
+
+        Assert.Equal([10, 20, 30], result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_preserves_ordering()
+    {
+        var source = CreateSource(5, 3, 1, 4, 2);
+        var observed = new List<int>();
+
+        var result = await CollectAsync(source.DoAsync(x => observed.Add(x)));
+
+        Assert.Equal([5, 3, 1, 4, 2], observed);
+        Assert.Equal([5, 3, 1, 4, 2], result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_does_not_enumerate_source_until_consumed()
+    {
+        var source = new TrackingAsyncEnumerable(1, 2, 3);
+
+        var tapped = source.DoAsync(_ => { });
+
+        Assert.False(source.EnumerationStarted);
+
+        await CollectAsync(tapped);
+
+        Assert.True(source.EnumerationStarted);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_with_pre_canceled_token_throws_OperationCanceledException()
+    {
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var source = CreateSource(1, 2, 3);
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            () => CollectAsync(source.DoAsync(_ => { }, tokenSource.Token))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_when_cancellation_requested_during_enumeration_throws_OperationCanceledException()
+    {
+        using var tokenSource = new CancellationTokenSource();
+
+        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
+
+        var tapped = source.DoAsync(_ => { }, tokenSource.Token);
+
+        await using var enumerator = tapped.GetAsyncEnumerator();
+
+        Assert.True(await enumerator.MoveNextAsync());
+
+        tokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            async () => await enumerator.MoveNextAsync()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_when_action_throws_propagates_exception()
+    {
+        var source = CreateSource(1, 2, 3);
+
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            () => CollectAsync(source.DoAsync(x =>
+            {
+                if (x == 2)
+                {
+                    throw new InvalidOperationException("test");
+                }
+            }))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_executes_action_before_yielding_item()
+    {
+        var source = CreateSource(1, 2, 3);
+        var log = new List<string>();
+
+        await foreach (var item in source.DoAsync(x => log.Add($"action:{x}")))
+        {
+            log.Add($"yield:{item}");
+        }
+
+        Assert.Equal
+        (
+            new[] { "action:1", "yield:1", "action:2", "yield:2", "action:3", "yield:3" },
+            log
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_when_source_has_items_executes_async_action_on_each()
+    {
+        var source = CreateSource(1, 2, 3);
+        var observed = new List<int>();
+
+        var result = await CollectAsync(source.DoAsync(async x =>
+        {
+            await Task.Yield();
+            observed.Add(x);
+        }));
+
+        Assert.Equal([1, 2, 3], observed);
+        Assert.Equal([1, 2, 3], result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_when_source_is_empty_executes_no_actions()
+    {
+        var source = CreateSource();
+        var observed = new List<int>();
+
+        var result = await CollectAsync(source.DoAsync(async x =>
+        {
+            await Task.Yield();
+            observed.Add(x);
+        }));
+
+        Assert.Empty(observed);
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_when_source_is_null_throws_ArgumentNullException()
+    {
+        IAsyncEnumerable<int> source = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>
+        (
+            () => CollectAsync(source.DoAsync(async _ => await Task.Yield()))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_when_action_is_null_throws_ArgumentNullException()
+    {
+        var source = CreateSource(1, 2, 3);
+
+        await Assert.ThrowsAsync<ArgumentNullException>
+        (
+            () => CollectAsync(source.DoAsync((Func<int, Task>)null!))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_yields_original_items_unchanged()
+    {
+        var source = CreateSource(10, 20, 30);
+
+        var result = await CollectAsync(source.DoAsync(_ => Task.CompletedTask));
+
+        Assert.Equal([10, 20, 30], result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_preserves_ordering()
+    {
+        var source = CreateSource(5, 3, 1, 4, 2);
+        var observed = new List<int>();
+
+        var result = await CollectAsync(source.DoAsync(x =>
+        {
+            observed.Add(x);
+            return Task.CompletedTask;
+        }));
+
+        Assert.Equal([5, 3, 1, 4, 2], observed);
+        Assert.Equal([5, 3, 1, 4, 2], result);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_does_not_enumerate_source_until_consumed()
+    {
+        var source = new TrackingAsyncEnumerable(1, 2, 3);
+
+        var tapped = source.DoAsync(_ => Task.CompletedTask);
+
+        Assert.False(source.EnumerationStarted);
+
+        await CollectAsync(tapped);
+
+        Assert.True(source.EnumerationStarted);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_with_pre_canceled_token_throws_OperationCanceledException()
+    {
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var source = CreateSource(1, 2, 3);
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            () => CollectAsync(source.DoAsync(_ => Task.CompletedTask, tokenSource.Token))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_when_cancellation_requested_during_enumeration_throws_OperationCanceledException()
+    {
+        using var tokenSource = new CancellationTokenSource();
+
+        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
+
+        var tapped = source.DoAsync(_ => Task.CompletedTask, tokenSource.Token);
+
+        await using var enumerator = tapped.GetAsyncEnumerator();
+
+        Assert.True(await enumerator.MoveNextAsync());
+
+        tokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            async () => await enumerator.MoveNextAsync()
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_when_action_throws_propagates_exception()
+    {
+        var source = CreateSource(1, 2, 3);
+
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            () => CollectAsync(source.DoAsync(x =>
+            {
+                if (x == 2)
+                {
+                    throw new InvalidOperationException("test");
+                }
+
+                return Task.CompletedTask;
+            }))
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_executes_action_before_yielding_item()
+    {
+        var source = CreateSource(1, 2, 3);
+        var log = new List<string>();
+
+        await foreach (var item in source.DoAsync(x =>
+        {
+            log.Add($"action:{x}");
+            return Task.CompletedTask;
+        }))
+        {
+            log.Add($"yield:{item}");
+        }
+
+        Assert.Equal
+        (
+            new[] { "action:1", "yield:1", "action:2", "yield:2", "action:3", "yield:3" },
+            log
+        );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Action_can_chain_with_ChunkAsync()
+    {
+        var source = CreateSource(1, 2, 3, 4, 5, 6);
+        var observed = new List<int>();
+
+        var chunks = new List<ICollection<int>>();
+        await foreach (var chunk in source.DoAsync(x => observed.Add(x)).ChunkAsync(3))
+        {
+            chunks.Add(chunk);
+        }
+
+        Assert.Equal([1, 2, 3, 4, 5, 6], observed);
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal([1, 2, 3], chunks[0]);
+        Assert.Equal([4, 5, 6], chunks[1]);
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_can_chain_with_ChunkAsync()
+    {
+        var source = CreateSource(1, 2, 3, 4, 5, 6);
+        var observed = new List<int>();
+
+        var chunks = new List<ICollection<int>>();
+        await foreach (var chunk in source.DoAsync(x =>
+        {
+            observed.Add(x);
+            return Task.CompletedTask;
+        }).ChunkAsync(3))
+        {
+            chunks.Add(chunk);
+        }
+
+        Assert.Equal([1, 2, 3, 4, 5, 6], observed);
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal([1, 2, 3], chunks[0]);
+        Assert.Equal([4, 5, 6], chunks[1]);
+    }
+
+
+
+    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            yield return value;
+        }
+    }
+
+    private static async IAsyncEnumerable<int> CreateDelayedSource(TimeSpan delay, params int[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Delay(delay);
+            yield return value;
+        }
+    }
+
+    private static async Task<List<int>> CollectAsync(IAsyncEnumerable<int> source)
+    {
+        var result = new List<int>();
+        await foreach (var item in source)
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    private sealed class TrackingAsyncEnumerable(params int[] values) : IAsyncEnumerable<int>
+    {
+        public bool EnumerationStarted { get; private set; }
+
+        public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            EnumerationStarted = true;
+            return CreateSource(values).GetAsyncEnumerator(cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DoAsync(Action<T>)` overload for synchronous side-effects (logging, metrics, debugging)
- Add `DoAsync(Func<T, Task>)` overload for asynchronous side-effects
- Both yield original items unchanged — pure pass-through with tap semantics
- Supports cancellation between items, lazy evaluation, and pipeline chaining

Closes #119

## Example
```csharp
// Synchronous — logging
await foreach (var item in source.DoAsync(x => Console.WriteLine($"Processing: {x}")))

// Asynchronous — async logging
await foreach (var batch in source
    .DoAsync(async x => await logger.LogAsync($"Processing: {x}"))
    .ChunkAsync(100))
```

## Test plan
- [x] 24 unit tests covering both overloads
- [x] Null guards (source, action) for both overloads
- [x] Empty source yields nothing, executes no actions
- [x] Items yielded unchanged, ordering preserved
- [x] Lazy evaluation (source not enumerated until consumed)
- [x] Pre-canceled token throws immediately
- [x] Mid-enumeration cancellation throws on next MoveNextAsync
- [x] Action exceptions propagate correctly
- [x] Action executes before item is yielded
- [x] Chaining with ChunkAsync works for both overloads
- [x] 100% line coverage, 100% method coverage
- [x] Build passes across all TFMs (net462, netstandard2.0, net8.0, net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)