### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>0.4.0</Version>
+		<Version>0.5.0</Version>
 		<Title>$(AssemblyName)</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A collection of extension methods for IAsyncEnumerable</Description>

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 	<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-	<Version>1.0.0</Version>
+	<Version>0.5.0</Version>
 	<LangVersion>latest</LangVersion>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- Bumps `Wolfgang.Extensions.IAsyncEnumerable` package version from 0.4.0 to 0.5.0.
- Syncs the test project version to 0.5.0.

## Test plan
- [ ] CI builds and tests pass on all target frameworks