### PR TITLE
docfx: sync from repo-template (gh-pages bootstrap fix)

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -335,7 +335,8 @@ jobs:
 
           # Set up gh-pages worktree (or start fresh if the branch does not exist yet)
           $branchExists = git ls-remote --heads origin gh-pages
-          if ($branchExists) {
+          $useWorktree = [bool]$branchExists
+          if ($useWorktree) {
             git fetch origin gh-pages
             git show-ref --verify --quiet refs/heads/gh-pages
             if ($LASTEXITCODE -ne 0) { git branch gh-pages origin/gh-pages }
@@ -345,6 +346,10 @@ jobs:
           } else {
             Write-Host "ℹ️ gh-pages does not exist yet — starting fresh."
             New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
+            # Initialize an empty repo on the gh-pages branch so the later
+            # add/commit/push commands have a real git repository to operate on.
+            git -C $WORK_DIR init --initial-branch=gh-pages
+            git -C $WORK_DIR remote add origin "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
           }
 
           # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME
@@ -414,4 +419,10 @@ jobs:
             Write-Host "ℹ️ No documentation changes to deploy."
           }
 
-          git worktree remove $WORK_DIR --force 2>&1 | Out-Null
+          if ($useWorktree) {
+            git worktree remove $WORK_DIR --force 2>&1 | Out-Null
+          } else {
+            Remove-Item $WORK_DIR -Recurse -Force -ErrorAction SilentlyContinue
+          }
+          # Reset $LASTEXITCODE so cleanup noise does not fail the step.
+          $global:LASTEXITCODE = 0


### PR DESCRIPTION
## Summary
Sync `.github/workflows/docfx.yaml` from `repo-template` to pick up the gh-pages bootstrap fix from [Chris-Wolfgang/repo-template#337](https://github.com/Chris-Wolfgang/repo-template/pull/337).

## What changed
The "Deploy docs to GitHub Pages" step had a latent bug: when the `gh-pages` branch did not yet exist on the remote, `$WORK_DIR` was created as a plain directory and the subsequent `git add` / `diff --cached` / `commit` / `push` failed with `fatal: not a git repository`. The fix initializes the directory as a git repo on `gh-pages` and adds the authenticated `origin` remote, so the existing add/commit/push works on a first-ever deploy. Cleanup also branches between `git worktree remove` (worktree path) and `Remove-Item` (fresh-repo path).

If `gh-pages` already exists in this repo (the common case), this change is a no-op at runtime — the bootstrap branch is only taken on a fresh repo.

## Test plan
- [ ] Workflow YAML lints / next docs deploy succeeds
- [ ] (Optional) verify `gh-pages` is unaffected