### PR TITLE
P1: BDN baselines for the rest of the public API surface (closes #183 in part)

### DIFF
--- a/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/DoAsyncBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/DoAsyncBenchmarks.cs
@@ -1,0 +1,62 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Wolfgang.Extensions.IAsyncEnumerable.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class DoAsyncBenchmarks
+{
+    private IReadOnlyList<int> _data = [];
+
+    [Params(1024, 4096, 16384)]
+    public int ItemCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new int[ItemCount];
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = i;
+        }
+
+        _data = buffer;
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> DoAsync_SyncAction()
+    {
+        var sum = 0;
+        await foreach (var item in CreateSource().DoAsync(x => sum += x, CancellationToken.None))
+        {
+            _ = item;
+        }
+        return sum;
+    }
+
+    [Benchmark]
+    public async Task<int> DoAsync_AsyncAction()
+    {
+        var sum = 0;
+        await foreach (var item in CreateSource().DoAsync(x => { sum += x; return Task.CompletedTask; }, CancellationToken.None))
+        {
+            _ = item;
+        }
+        return sum;
+    }
+
+    private async IAsyncEnumerable<int> CreateSource
+    (
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        foreach (var value in _data)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return value;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/EmptyCheckAsyncBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/EmptyCheckAsyncBenchmarks.cs
@@ -1,0 +1,59 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Wolfgang.Extensions.IAsyncEnumerable.Benchmarks;
+
+/// <summary>
+/// IsEmptyAsync and IsNullOrEmptyAsync are O(1) on the first element — these benchmarks
+/// also exercise the non-empty path (must materialize the first element via MoveNextAsync)
+/// to keep the comparison honest.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class EmptyCheckAsyncBenchmarks
+{
+    private IReadOnlyList<int> _empty = [];
+    private IReadOnlyList<int> _nonEmpty = [];
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _empty = [];
+        _nonEmpty = [1, 2, 3];
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<bool> IsEmptyAsync_Empty()
+        => await CreateSource(_empty).IsEmptyAsync(CancellationToken.None);
+
+    [Benchmark]
+    public async Task<bool> IsEmptyAsync_NonEmpty()
+        => await CreateSource(_nonEmpty).IsEmptyAsync(CancellationToken.None);
+
+    [Benchmark]
+    public async Task<bool> IsNullOrEmptyAsync_Null()
+        => await IAsyncEnumerableExtensions.IsNullOrEmptyAsync<int>(null, CancellationToken.None);
+
+    [Benchmark]
+    public async Task<bool> IsNullOrEmptyAsync_Empty()
+        => await CreateSource(_empty).IsNullOrEmptyAsync(CancellationToken.None);
+
+    [Benchmark]
+    public async Task<bool> IsNullOrEmptyAsync_NonEmpty()
+        => await CreateSource(_nonEmpty).IsNullOrEmptyAsync(CancellationToken.None);
+
+    private async IAsyncEnumerable<int> CreateSource
+    (
+        IReadOnlyList<int> data,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        foreach (var value in data)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return value;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/ForEachAsyncBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/ForEachAsyncBenchmarks.cs
@@ -1,0 +1,56 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Wolfgang.Extensions.IAsyncEnumerable.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class ForEachAsyncBenchmarks
+{
+    private IReadOnlyList<int> _data = [];
+
+    [Params(1024, 4096, 16384)]
+    public int ItemCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new int[ItemCount];
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = i;
+        }
+
+        _data = buffer;
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<int> ForEachAsync_SyncAction()
+    {
+        var sum = 0;
+        await CreateSource().ForEachAsync(x => sum += x, CancellationToken.None);
+        return sum;
+    }
+
+    [Benchmark]
+    public async Task<int> ForEachAsync_AsyncAction()
+    {
+        var sum = 0;
+        await CreateSource().ForEachAsync(x => { sum += x; return Task.CompletedTask; }, CancellationToken.None);
+        return sum;
+    }
+
+    private async IAsyncEnumerable<int> CreateSource
+    (
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        foreach (var value in _data)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return value;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/NoneAsyncBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/NoneAsyncBenchmarks.cs
@@ -1,0 +1,57 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Wolfgang.Extensions.IAsyncEnumerable.Benchmarks;
+
+/// <summary>
+/// NoneAsync has two overloads (no predicate / with predicate). The no-predicate
+/// variant short-circuits at the first element; the predicate variant walks until
+/// it finds a match (worst case: full enumeration when no element matches).
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class NoneAsyncBenchmarks
+{
+    private IReadOnlyList<int> _data = [];
+
+    [Params(1024, 4096, 16384)]
+    public int ItemCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new int[ItemCount];
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = i;
+        }
+
+        _data = buffer;
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<bool> NoneAsync_NoPredicate_NonEmpty()
+        => await CreateSource().NoneAsync(CancellationToken.None);
+
+    [Benchmark]
+    public async Task<bool> NoneAsync_Predicate_NoneMatch()
+        => await CreateSource().NoneAsync(static x => x < 0, CancellationToken.None);
+
+    [Benchmark]
+    public async Task<bool> NoneAsync_Predicate_FirstMatches()
+        => await CreateSource().NoneAsync(static x => x == 0, CancellationToken.None);
+
+    private async IAsyncEnumerable<int> CreateSource
+    (
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        foreach (var value in _data)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return value;
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Only `ChunkAsync` had a benchmark. Adds 4 new BDN classes following the existing `ChunkAsyncBenchmarks` pattern (`[MemoryDiagnoser]`, `net8.0 SimpleJob`, async `IAsyncEnumerable<int>` source via local `[EnumeratorCancellation]` iterator), covering the other five public-API method groups.

## New benchmark classes

| Class | Public APIs benched |
|---|---|
| `DoAsyncBenchmarks` | `DoAsync<T>(source, Action<T>, ct)` + `DoAsync<T>(source, Func<T, Task>, ct)` |
| `ForEachAsyncBenchmarks` | `ForEachAsync<T>(source, Action<T>, ct)` + `ForEachAsync<T>(source, Func<T, Task>, ct)` |
| `EmptyCheckAsyncBenchmarks` | `IsEmptyAsync<T>(source, ct)` + `IsNullOrEmptyAsync<T>(source?, ct)` — null/empty/non-empty paths |
| `NoneAsyncBenchmarks` | `NoneAsync<T>(source, ct)` + `NoneAsync<T>(source, predicate, ct)` — first-match/no-match/short-circuit paths |

## Closes (in part)

- #183 — every public API now has a baseline benchmark. The "BDN baseline" half is now complete; P2 (#184, publish results to gh-pages) is the remaining half.

## Stacked on

`vNext` (PR #214). Will fold in cleanly when the v0.5.1 release ships.

## Verification

Built once locally with the existing `ChunkAsyncBenchmarks` pattern; all four new classes compile clean and use the same conventions (analyzer-clean, `MemoryDiagnoser`, parameterized `ItemCount`, deterministic seeded data).