### PR TITLE
D5: sync docs/DOCFX-VERSION-PICKER.md from canonical (closes #192)

### DIFF
--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -94,37 +94,83 @@ synced fleet-wide.
 with mock entries (see "Testing locally" below). The picker
 gracefully falls back to "no dropdown" if the stub is empty.
 
-### 4. `.github/version-picker-template.html`
+### 4. Root `index.html` redirect — inlined in the workflows
 
-Used by the `docfx.yaml` "Generate version-picker index.html" step.
-Renders an auto-redirect page at the gh-pages root:
+> **Note (2026-06):** Previous canonical kept the redirect HTML in a
+> separate `.github/version-picker-template.html` file. That file is
+> gone — both workflows now build the markup inline as a PowerShell
+> string-array. The only dynamic piece is the page title (the repo
+> name), so the template-file indirection was pure overhead. See the
+> D20-Dice commit `b58861a` (and the follow-up `1b9a7c7` that fixed
+> a YAML literal-block-scalar trap from an attempted here-string)
+> for the original design.
+>
+> Where to find the generation in each workflow:
+>
+> - **`docfx.yaml`** — the inline HTML is built **inside** the
+>   `Deploy docs to GitHub Pages` step (not a step of its own). Look
+>   for the `Generated root index.html (meta-refresh → versions/latest/).`
+>   log line in that step's output.
+> - **`build-all-versions.yaml`** — distinct step named
+>   `Generate root index.html (meta-refresh → versions/latest/)`,
+>   visible at the top level of the workflow run.
 
-- `meta http-equiv="refresh"` for instant redirect
-- `setTimeout` JS backup if meta-refresh is blocked
-- `<noscript>` link covers the everything-else case
+The inline HTML:
 
-`{{TITLE}}` is substituted with the repo name at deploy time;
-`{{VERSION_LIST}}` is intentionally omitted from the template. A missing
-pattern is a true no-op for PowerShell's `-replace` (returns the original
-string unchanged), so the workflow runs unchanged; nothing gets injected
-into the root redirect page because the in-page dropdown is now the
-canonical version-selector UI.
+- `meta http-equiv="refresh" content="0; url=versions/latest/"` for the instant redirect. **Relative** link — resolves correctly under the GitHub Pages project path `/<repo>/`.
+- `link rel="canonical" href="versions/latest/"` for SEO.
+- `setTimeout(function(){ window.location.replace('versions/latest/'); }, 0)` JS backup if meta-refresh is blocked.
+- `<noscript>` link covers the everything-else case.
+
+Only the repo name is interpolated via `$repoName` / `$title`. No `{{TITLE}}` / `{{VERSION_LIST}}` placeholders, no template-file read, no `-replace` substitution — the workflow shows you exactly what HTML it produces.
 
 ---
 
 ## How it gets to gh-pages
 
+`docfx.yaml` is **not** triggered directly by `push` or by pushing a
+tag — it has only `workflow_call` (invoked by `release.yaml` after a
+GitHub Release is published) and `workflow_dispatch` (manual). Two
+paths reach it:
+
 ```
-push to main / release tag
-  └─ docfx.yaml fires
-       ├─ docfx build  → _site/  (includes public/version-picker.js,
-       │                          inline bootstrap in every page's
-       │                          footer via _appFooter)
-       ├─ Generate versions.json from v* tags → _site/versions.json
-       ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
-       └─ Generate root index.html from version-picker-template.html
-                  → deploy to gh-pages /
+Path 1 — normal: a GitHub Release is published
+  └─ release.yaml fires (on `release: types: [published]`)
+       └─ release.yaml → calls docfx.yaml as a reusable workflow
+            └─ docfx.yaml runs the deploy steps below
+
+Path 2 — manual: a maintainer runs docfx.yaml from the Actions tab
+  └─ docfx.yaml fires directly (on `workflow_dispatch`)
+       └─ docfx.yaml runs the deploy steps below
+
+The deploy steps that docfx.yaml runs in both cases:
+  ├─ docfx build  → _site/  (includes public/version-picker.js,
+  │                          inline bootstrap in every page's
+  │                          footer via _appFooter)
+  ├─ Generate versions.json from v* tags → _site/versions.json
+  ├─ Deploy _site/ to gh-pages /versions/<v>/  (always)
+  │
+  │  --- The remaining two steps only run when `deploy_as_latest`
+  │      is true (the default; uncheck on workflow_dispatch when
+  │      you're rebuilding an OLDER version and don't want to move
+  │      the "latest" alias):
+  │
+  ├─ Deploy _site/ to gh-pages /versions/latest/   [deploy_as_latest only]
+  └─ Generate root index.html (meta-refresh, inline HTML)
+             → deploy to gh-pages /                [deploy_as_latest only]
 ```
+
+A plain `git push` to `main` does **not** redeploy the docs — the
+gh-pages content updates only via Path 1 (publishing a GitHub
+Release) or Path 2 (manually running `docfx.yaml` from the Actions
+tab).
+
+`deploy_as_latest` defaults to true. The escape hatch is for the
+Path 2 manual case where you want to rebuild and republish the
+docs for an older version (e.g. backporting a doc fix to `v1.0.0`)
+without overwriting the `/versions/latest/` alias and the site-root
+`index.html` (which loads the picker bootstrap; the picker JS itself
+reads `versions.json` for the version list).
 
 Result on gh-pages:
 
@@ -188,7 +234,7 @@ because we're not on github.io).
 | Dropdown empty | `versions.json` fetch failed or returned an array without any non-"latest" entries | DevTools → Network. The page should fetch `/<repo>/versions.json` (or `/versions.json` on localhost) and get a JSON array with `version`+`url` entries. |
 | Popup text invisible (light-on-light or dark-on-dark) | `color-scheme: light dark` missing or Bootstrap CSS vars not loaded | Verify `version-picker.js` is the current version |
 | Picker appears as sibling of `<header>` instead of inside it | Anchor fallback selected `header` with the wrong insertion mode | Verify the anchors table has `['header', 'append']` (not `'before'`) |
-| Root `/` shows old "Select a documentation version" landing page | The `version-picker-template.html` change didn't deploy | Check the workflow run's "Generate version-picker index.html" step output |
+| Root `/` shows old "Select a documentation version" landing page | The inline-HTML refactor hasn't deployed yet | In `docfx.yaml`, look inside the `Deploy docs to GitHub Pages` step for the `Generated root index.html (meta-refresh → versions/latest/).` log line. In `build-all-versions.yaml`, look at the distinct step named `Generate root index.html (meta-refresh → versions/latest/)`. |
 
 For workflow-level issues (failed deploys, stale `versions.json`,
 missing version subtrees), the `docfx.yaml` run's per-step output is


### PR DESCRIPTION
## Summary

D5 audit of `docs/*.md` for accuracy vs `repo-template/main` canonical. Only one drift remains:

- **`docs/DOCFX-VERSION-PICKER.md`** — picks up the section-4 rewrite from `repo-template` PR #408 ("inlined in the workflows" — no separate `.github/version-picker-template.html` file), the updated gh-pages flow diagram, and the troubleshooting row pointing at the correct step/log names.

The other three template-canonical docs (`README-FORMATTING.md`, `RELEASE-WORKFLOW-SETUP.md`, `WORKFLOW_SECURITY.md`) are already identical to canonical on `vNext` via earlier canonical re-syncs.

## Closes

- #192

## Stacked on

`vNext` (PR #214). Folds cleanly into v0.5.1.