### PR TITLE
C5: XML doc clarifications surfaced by code-review pass (closes #181)

### DIFF
--- a/src/Wolfgang.Extensions.IAsyncEnumerable/IAsyncEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/IAsyncEnumerableExtensions.cs
@@ -98,6 +98,13 @@ public static class IAsyncEnumerableExtensions
     /// Executes a synchronous side-effect action on each element of an IAsyncEnumerable{T}
     /// without transforming the elements. The original items are yielded unchanged.
     /// </summary>
+    /// <remarks>
+    /// Exceptions thrown by <paramref name="action"/> propagate to the consuming
+    /// <c>await foreach</c> and terminate the enumeration. The cancellation token is
+    /// observed between elements (after each <c>yield return</c>), not while the action
+    /// is running — wrap long-running actions in their own cancellation if mid-action
+    /// cancellation is required.
+    /// </remarks>
     /// <param name="source">The source IAsyncEnumerable{T}.</param>
     /// <param name="action">The synchronous action to execute on each element.</param>
     /// <param name="token">A cancellation token to cancel the operation.</param>
@@ -355,7 +362,13 @@ public static class IAsyncEnumerableExtensions
     /// <summary>
     /// Asynchronously determines whether a sequence is null or contains no elements.
     /// </summary>
-    /// <param name="source">The IAsyncEnumerable{T} to check.</param>
+    /// <remarks>
+    /// Unlike <see cref="IsEmptyAsync{T}"/>, this method is null-tolerant: passing a
+    /// null <paramref name="source"/> returns <c>true</c> without throwing. The
+    /// cancellation token is observed only when the source is non-null (a null source
+    /// short-circuits before any token check).
+    /// </remarks>
+    /// <param name="source">The IAsyncEnumerable{T} to check. May be null.</param>
     /// <param name="token">A cancellation token to cancel the operation.</param>
     /// <typeparam name="T">The type of elements in the IAsyncEnumerable{T}.</typeparam>
     /// <returns>
@@ -394,6 +407,12 @@ public static class IAsyncEnumerableExtensions
     /// <summary>
     /// Asynchronously determines whether a sequence contains no elements.
     /// </summary>
+    /// <remarks>
+    /// This overload is a naming alias for <see cref="IsEmptyAsync{T}"/> — the two
+    /// are observationally equivalent. Pick whichever reads more naturally at the
+    /// call site (e.g. <c>await source.NoneAsync()</c> as a guard, or
+    /// <c>await source.IsEmptyAsync()</c> as a state check).
+    /// </remarks>
     /// <param name="source">The IAsyncEnumerable{T} to check.</param>
     /// <param name="token">A cancellation token to cancel the operation.</param>
     /// <typeparam name="T">The type of elements in the IAsyncEnumerable{T}.</typeparam>


### PR DESCRIPTION
## Summary

Three XML-doc clarifications from the [#174 code-review findings](https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/issues/174#issuecomment-4631556648). No behaviour changes; no public-API signature changes.

## Clarifications

1. **`IsNullOrEmptyAsync`** — added `<remarks>` calling out the null-tolerance contract explicitly (returns `true` on null source, no `ArgumentNullException`) and the cancellation-token observation order (only when source is non-null).
2. **`NoneAsync` (no-predicate overload)** — added `<remarks>` noting it's observationally equivalent to `IsEmptyAsync` (which it internally delegates to), so readers can pick whichever reads more naturally at the call site.
3. **`DoAsync` (sync `Action<T>` overload)** — added `<remarks>` documenting the exception-propagation behaviour and the between-elements cancellation timing.

## Closes

- #181

## Not addressed in this PR

The fourth observation from #174 — `ChunkCoreAsync` array-pool experiment — needs benchmark data to justify (run new `ChunkAsyncBenchmarks` against a `ChunkAsyncV2` candidate and compare). Tracked as a separate follow-up; would land as its own benchmark-driven optimization PR.

## Stacked on

`vNext` (PR #214).