### PR TITLE
T4: close concrete test-coverage gaps (closes #208)

### DIFF
--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/IsNullOrEmptyAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/IsNullOrEmptyAsyncTests.cs
@@ -66,6 +66,23 @@ public sealed class IsNullOrEmptyAsyncTests
 
 
 
+    [Fact]
+    public async Task IsNullOrEmptyAsync_when_source_is_null_and_token_is_canceled_returns_true()
+    {
+        // Documents the null-tolerance contract: when source is null, the method
+        // short-circuits before observing the cancellation token. A canceled token
+        // is therefore irrelevant on a null source — the method must still return
+        // true, not throw OperationCanceledException.
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var result = await IAsyncEnumerableExtensions.IsNullOrEmptyAsync<int>(null, tokenSource.Token);
+
+        Assert.True(result);
+    }
+
+
+
     private static async IAsyncEnumerable<int> CreateSource(params int[] values)
     {
         foreach (var value in values)

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/NoneAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/NoneAsyncTests.cs
@@ -159,6 +159,48 @@ public sealed class NoneAsyncTests
 
 
 
+    [Fact]
+    public async Task NoneAsync_predicate_when_predicate_throws_exception_propagates()
+    {
+        var source = CreateSource(1, 2, 3);
+        var sentinel = new InvalidOperationException("predicate boom");
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            () => source.NoneAsync(_ => throw sentinel)
+        );
+
+        Assert.Same(sentinel, actual);
+    }
+
+
+
+    [Fact]
+    public async Task NoneAsync_predicate_when_token_canceled_mid_iteration_throws_OperationCanceledException()
+    {
+        // Token starts uncanceled, so the upfront ThrowIfCancellationRequested passes.
+        // The first predicate invocation cancels the token; the post-predicate
+        // ThrowIfCancellationRequested (NoneAsync predicate-overload, source line 467)
+        // is what we're exercising.
+        using var tokenSource = new CancellationTokenSource();
+        var source = CreateSource(1, 2, 3);
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            () => source.NoneAsync
+            (
+                _ =>
+                {
+                    tokenSource.Cancel();
+                    return false;  // don't short-circuit — let the post-predicate token check fire
+                },
+                tokenSource.Token
+            )
+        );
+    }
+
+
+
     private static async IAsyncEnumerable<int> CreateSource(params int[] values)
     {
         foreach (var value in values)


### PR DESCRIPTION
## Summary

Adds three tests covering specific contract behaviours the existing suite didn't exercise. Each is grounded in a finding from the [#174 code-review pass](https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/issues/174#issuecomment-4631556648) — they document real public-contract obligations, not coverage padding.

## New tests

### 1. `NoneAsyncTests.NoneAsync_predicate_when_predicate_throws_exception_propagates`
A predicate-thrown exception flows to the caller intact (`Assert.Same` on a sentinel `InvalidOperationException`). Documents that the async state machine doesn't swallow it.

### 2. `NoneAsyncTests.NoneAsync_predicate_when_token_canceled_mid_iteration_throws_OperationCanceledException`
The post-predicate `token.ThrowIfCancellationRequested()` (source line 467) actually fires. The existing `_pre_canceled_token_` tests only cover the upfront check; this one cancels *inside* the predicate body so only the inner-loop check can catch it.

### 3. `IsNullOrEmptyAsyncTests.IsNullOrEmptyAsync_when_source_is_null_and_token_is_canceled_returns_true`
Documents that `null` source short-circuits **before** any cancellation observation — a canceled token on a null source must still return `true`, not throw `OperationCanceledException`. Pairs with the explicit `<remarks>` XML doc added by PR #224.

## Verification

```
dotnet test tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit.csproj
  --framework net10.0
  --filter "<3 new test names>"
→ Passed: 3, Failed: 0
```

## Closes

- #208

## Not in scope for this PR

The findings comment also flagged duplication between `DoAsync`/`ForEachAsync` sync+async tests (good `[Theory]` consolidation candidates). That refactor cuts ~150 lines without changing coverage — separate PR, after the v0.5.1 release ships to avoid coupling.

## Stacked on

`vNext` (PR #214). Folds into v0.5.1.

## Build caveat

Release build is currently blocked by #223 (pre-existing RS0017 quirk). Debug build is clean; the three new tests pass.