### PR TITLE
C5 follow-up: thorough-review quick wins (batch 1 of #181)

### DIFF
--- a/src/Wolfgang.Extensions.IAsyncEnumerable/IAsyncEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/IAsyncEnumerableExtensions.cs
@@ -4,9 +4,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-[assembly: InternalsVisibleTo("Wolfgang.Extensions.IAsyncEnumerable.Benchmarks")]
-[assembly: InternalsVisibleTo("Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit")]
-
 namespace Wolfgang.Extensions.IAsyncEnumerable;
 
 /// <summary>
@@ -87,8 +84,12 @@ public static class IAsyncEnumerableExtensions
                 yield break;
             }
 
-            Array.Resize(ref array, index);
-            yield return array;
+            // Right-sized copy is one allocation + one copy; Array.Resize did
+            // the same work plus an extra bookkeeping step. The final-chunk
+            // array escapes the method, so pooling isn't safe.
+            var tail = new T[index];
+            Array.Copy(array, tail, index);
+            yield return tail;
         }
     }
 
@@ -355,7 +356,13 @@ public static class IAsyncEnumerableExtensions
     /// <summary>
     /// Asynchronously determines whether a sequence is null or contains no elements.
     /// </summary>
-    /// <param name="source">The IAsyncEnumerable{T} to check.</param>
+    /// <remarks>
+    /// Unlike <see cref="IsEmptyAsync{T}"/>, this method is null-tolerant: passing a
+    /// null <paramref name="source"/> returns <c>true</c> without throwing. The
+    /// cancellation token is observed only when the source is non-null (a null source
+    /// short-circuits before any token check).
+    /// </remarks>
+    /// <param name="source">The IAsyncEnumerable{T} to check. May be null.</param>
     /// <param name="token">A cancellation token to cancel the operation.</param>
     /// <typeparam name="T">The type of elements in the IAsyncEnumerable{T}.</typeparam>
     /// <returns>
@@ -369,24 +376,15 @@ public static class IAsyncEnumerableExtensions
     /// }
     /// </code>
     /// </example>
-    public static async Task<bool> IsNullOrEmptyAsync<T>
+    public static Task<bool> IsNullOrEmptyAsync<T>
     (
         this IAsyncEnumerable<T>? source,
         CancellationToken token = default
     )
     {
-        if (source is null)
-        {
-            return true;
-        }
-
-        token.ThrowIfCancellationRequested();
-
-        var enumerator = source.GetAsyncEnumerator(token);
-        await using (enumerator.ConfigureAwait(false))
-        {
-            return !await enumerator.MoveNextAsync().ConfigureAwait(false);
-        }
+        return source is null
+            ? Task.FromResult(true)
+            : IsEmptyAsync(source, token);
     }
 
 
@@ -394,10 +392,16 @@ public static class IAsyncEnumerableExtensions
     /// <summary>
     /// Asynchronously determines whether a sequence contains no elements.
     /// </summary>
+    /// <remarks>
+    /// This overload is a naming alias for <see cref="IsEmptyAsync{T}"/> — the two
+    /// are observationally equivalent. Pick whichever reads more naturally at the
+    /// call site (e.g. <c>await source.NoneAsync()</c> as a guard, or
+    /// <c>await source.IsEmptyAsync()</c> as a state check).
+    /// </remarks>
     /// <param name="source">The IAsyncEnumerable{T} to check.</param>
     /// <param name="token">A cancellation token to cancel the operation.</param>
     /// <typeparam name="T">The type of elements in the IAsyncEnumerable{T}.</typeparam>
-    /// <returns>false if the source sequence contains any elements; otherwise, true.</returns>
+    /// <returns>true if the source sequence contains no elements; otherwise, false.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> is null.</exception>
     /// <example>
     /// <code>


### PR DESCRIPTION
## Summary

Four non-breaking improvements from the line-by-line code review on [#181](https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/issues/181#issuecomment-4636611916). All 76 existing tests pass.

## Changes

| # | Severity | Change |
|---|---|---|
| 1 | 🔴 must-fix | Remove dead `[assembly: InternalsVisibleTo]` for `Benchmarks` + `Tests.Unit` — the source has zero internal members; tests + benchmarks use only the public API. |
| 2 | 🟡 should-fix | DRY `IsNullOrEmptyAsync` — it now delegates to `IsEmptyAsync` after a null short-circuit, matching the pattern `NoneAsync` (no-predicate) already follows. -15 LoC. |
| 3 | 🟡 should-fix | `NoneAsync` no-predicate `<returns>` phrasing — replace negation-style with positive form matching `IsEmptyAsync`. |
| 4 | 🟡 should-fix | `ChunkCoreAsync` final-chunk allocation — replace `Array.Resize(ref, index)` with explicit `new T[index] + Array.Copy`. Same allocation count, less work. Documents why the array is not pooled. |

## Out of scope (separate PRs)

Per the [#181 review's recommended sequence](https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/issues/181#issuecomment-4636611916):
- Batch 2 (additive API): `Func<T, CancellationToken, Task>` overloads for `DoAsync` / `ForEachAsync`
- Batch 3 (breaking, next major): change `ChunkAsync` return type from `ICollection<T>` to `IReadOnlyList<T>`
- Batch 4 (speculative perf, needs measurement): `ChunkCoreAsync` allocation optimization
- Batch 5 (cross-cutting style): `ArgumentNullException.ThrowIfNull` polyfill

## Verification

```
dotnet build              → 0 Warning(s) 0 Error(s)
dotnet test --framework net10.0
                          → Passed: 76, Failed: 0
```

## Stacked on

`vNext` (PR #214). Folds cleanly into v0.5.1. Public API surface unchanged.