### PR TITLE
Sync scripts/build-pr.ps1 from canonical repo-template

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -302,7 +302,11 @@ if (-not $SkipSecurity) {
             # is on PATH by default on most Linux distros and macOS; if not, prepend it.
             $localBin = Join-Path $HOME ".local/bin"
             New-Item -ItemType Directory -Force -Path $localBin | Out-Null
-            curl -sSfL $url | tar xz -C $localBin gitleaks
+            # Use 'tar -f -' so extraction reads the gitleaks archive from
+            # stdin. GNU tar without '-f' defaults to /dev/tape (or another
+            # default depending on the TAPE env var), which can hang silently
+            # in CI / fresh shells.
+            curl -sSfL $url | tar -xz -f - -C $localBin gitleaks
             if (-not ($env:PATH -split [IO.Path]::PathSeparator | Where-Object { $_ -eq $localBin })) {
                 $env:PATH = "$localBin$([IO.Path]::PathSeparator)$env:PATH"
             }


### PR DESCRIPTION
## Summary

Template drift fix — the only real drift the `template-drift-scan` found post-v0.5.1.

`repo-template` updated `scripts/build-pr.ps1`'s gitleaks-download `tar` invocation on 2026-06-02 to pass `-f -` explicitly, avoiding the default `/dev/tape` lookup that can hang silently in CI / fresh shells.

This repo had the 2026-05-25 version. One-line behavioural fix, no other changes.

## Test plan
- [x] `scripts/build-pr.ps1` byte-identical to `repo-template@main` for this file
- [ ] CI green (gitleaks + DevSkim + Stage 1/2/3)

Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)