### PR TITLE
docfx.json: wire favicon assets (was silently skipped in earlier fanout)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -33,13 +33,15 @@
       {
         "files": [
           "logo.svg",
+          "apple-touch-icon.png",
+          "favicon.ico",
+          "favicon.svg",
           "images/**",
           "public/**",
           "versions.json"
         ]
       }
     ],
-    // Note: "../docs" is used as the DocFX output directory for GitHub Actions deployment and is git-ignored for local builds.
     "output": "_site",
     "template": [
       "default",
@@ -49,6 +51,7 @@
       "_appName": "Wolfgang.Extensions.IAsyncEnumerable",
       "_appTitle": "Wolfgang.Extensions.IAsyncEnumerable Documentation",
       "_appLogoPath": "logo.svg",
+      "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
       "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "_disableSidebar": false,


### PR DESCRIPTION
## Summary

The earlier favicon fanout added the assets but its docfx.json patch silently failed. This PR wires them up:

- `build.resource[0].files` — adds favicon.svg, favicon.ico, apple-touch-icon.png
- `build.globalMetadata._appFaviconPath` — set to `favicon.svg`