### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dependabot bump: dotnet-dependencies group (2 packages).
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
 ## [0.5.1] - 2026-06-06
 
 No public API changes. This release is a maintenance / infrastructure refresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.5.2] - 2026-07-06
+
+### Changed
+
+- Dependabot bump: dotnet-dependencies group (2 packages).
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.5.1] - 2026-06-06
 
 No public API changes. This release is a maintenance / infrastructure refresh
@@ -124,5 +142,6 @@ plus a fix for a Release-build blocker.
   without an explicit maintainer admin-bypass.
 - `persist-credentials: false` on the gitleaks / stryker checkouts.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.0...v0.5.1

--- a/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>14</LangVersion>
-		<Version>0.5.1</Version>
+		<Version>0.5.2</Version>
 		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 		     do not need to recompile / add binding redirects on every minor/patch
 		     bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Release prep — v0.5.2

Bump `<Version>` in `src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj` from `0.5.1` to `0.5.2`, promote `[Unreleased]` in CHANGELOG.md, add compare-link.

### Section

```
### Changed
- Dependabot bump: dotnet-dependencies group (2 packages).
```

## After merge

Create the release: `gh release create v0.5.2 --target main --title "v0.5.2" --generate-notes` (or via UI). The release.yaml workflow fires on `release: published` and handles the NuGet publish.