### PR TITLE
docs: establish migration-guide convention for major-version releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/migrations/TEMPLATE-major-version-migration.md` establishing the
+  migration-guide convention for future major-version releases (#244).
+
 ### Changed
 
 ### Deprecated

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,47 @@
+# Migrating from vX to vY
+
+> Copy this file to `docs/migrations/vX-to-vY.md` when preparing a major-version
+> release, fill in the sections below, and link it from the GitHub Release notes.
+> Write it during release prep — retrofitting a migration guide after a major
+> version has already shipped is far more expensive than writing it alongside
+> the breaking changes.
+
+## Summary
+
+One or two sentences: what changed and why a major bump was required.
+
+## Breaking-change inventory
+
+| API | Change | Replacement |
+|-----|--------|--------------|
+| `OldMethod(...)` | Removed | `NewMethod(...)` |
+| `SomeType.Property` | Renamed to `NewProperty` | `SomeType.NewProperty` |
+| `SomeMethod(int)` | Behavior change: now throws on negative input | Validate input before calling, or catch `ArgumentOutOfRangeException` |
+
+Every entry in `PublicAPI.Shipped.txt` removed or changed between the last
+minor of vX and the first release of vY belongs in this table.
+
+## Before / after code samples
+
+```csharp
+// vX
+var result = await source.OldMethod(x => x.Value);
+
+// vY
+var result = await source.NewMethod(x => x.Value);
+```
+
+Add one before/after pair per breaking change in the inventory above.
+
+## Deprecation timeline
+
+If the old API was marked `[Obsolete]` ahead of removal, note when:
+
+- vX.Y: `[Obsolete]` warning added, old API still functional
+- vY.0: old API removed
+
+## Getting help
+
+Open an issue at
+https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/issues if a
+migration path isn't covered here.


### PR DESCRIPTION
## Summary
- Adds `docs/migrations/TEMPLATE-major-version-migration.md` per #244's acceptance criteria: breaking-change inventory table, before/after code samples, deprecation timeline.
- Establishes the convention now (no major version has shipped yet) so it's ready when the first breaking release happens, rather than retrofitted after the fact.

Closes #244

Part of the thorough-review campaign — targets `vNext`, not `main` (per repo convention, `Closes #N` will fire once vNext merges to main).