### PR TITLE
docs: add Architecture Decision Records (docs/adr/)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/adr/` — Architecture Decision Records: `TEMPLATE.md`, `index.md`,
+  and four retroactive ADRs covering the AssemblyVersion pin, the two
+  `DoAsync` overloads, `ChunkAsync`'s `ICollection<T>` return type, and
+  the `BannedSymbols.txt` async-first enforcement policy (#245).
+
 ### Changed
 
 ### Deprecated

--- a/docs/adr/0001-pin-assemblyversion-to-1.0.0.0.md
+++ b/docs/adr/0001-pin-assemblyversion-to-1.0.0.0.md
@@ -1,0 +1,46 @@
+# ADR-0001: Pin AssemblyVersion to a fixed 1.0.0.0 baseline
+
+## Status
+
+Accepted
+
+## Context
+
+.NET distinguishes `AssemblyVersion` (the strong-name identity the CLR uses
+for binding at load time) from `FileVersion` / `InformationalVersion` (the
+human-facing release version, e.g. the NuGet `<Version>`). If
+`AssemblyVersion` tracks the NuGet version 1:1, every minor or patch release
+changes the assembly's binding identity. A consumer that references the
+library directly (not solely through a `PackageReference` that floats to the
+latest resolvable version) would need a binding redirect — or a recompile —
+on every single-digit bump, even though nothing about the public API
+actually broke.
+
+Wolfgang.Extensions.IAsyncEnumerable ships frequent, additive minor/patch
+releases (new extension methods, bug fixes). Forcing consumers to react to
+binding-identity churn on every one of those releases would defeat the
+purpose of semantic versioning: MINOR and PATCH bumps are supposed to be
+safe, no-action-required upgrades.
+
+## Decision
+
+`AssemblyVersion` is pinned at `1.0.0.0` and only bumped on a deliberate
+breaking API change (i.e., in step with a MAJOR version bump). `FileVersion`
+and `InformationalVersion` continue to track the real `<Version>` from the
+csproj on every release, so tooling that inspects the physical DLL (Explorer
+properties, `dotnet --info`-style diagnostics, crash dumps) still shows the
+precise shipped version.
+
+## Consequences
+
+- Consumers referencing the assembly directly never need a binding redirect
+  for a MINOR/PATCH release — only for a MAJOR one, which is exactly when a
+  breaking change (and therefore a recompile) is expected anyway.
+- Two different NuGet package versions (e.g. 0.5.1 and 0.5.2) produce
+  assemblies with the *same* `AssemblyVersion`. Tooling that assumes
+  `AssemblyVersion` uniquely identifies a release (rather than `FileVersion`)
+  will see them as identical — this is intentional, not a bug.
+- The `AssemblyVersion` bump must be a conscious, reviewed step tied to a
+  MAJOR release, not something automated by the same mechanism that bumps
+  `<Version>` — a missed bump on an actual breaking change would silently
+  reintroduce the binding-conflict problem this ADR exists to avoid.

--- a/docs/adr/0002-two-doasync-overloads-instead-of-one.md
+++ b/docs/adr/0002-two-doasync-overloads-instead-of-one.md
@@ -1,0 +1,44 @@
+# ADR-0002: Two `DoAsync` overloads instead of a single merged one
+
+## Status
+
+Accepted
+
+## Context
+
+`DoAsync` executes a side-effect on every element as it streams through,
+without transforming the sequence — the async analogue of Rx's `Do`. Callers
+need it for both a synchronous side effect (`Action<T>`, e.g.
+`Console.WriteLine`) and an asynchronous one (`Func<T, Task>`, e.g. an async
+logger call). A single merged overload taking `Func<T, Task>` and requiring
+synchronous callers to write `x => { DoTheThing(x); return Task.CompletedTask; }`
+was considered, as was accepting `Delegate` and dispatching on the runtime
+type.
+
+The `Delegate`-based single-overload approach loses compile-time type
+checking (a caller could pass an unrelated delegate shape and only find out
+at runtime) and pays a reflection-based dispatch cost on every element. The
+`Func<T, Task>`-only approach pushes syntactic noise onto every synchronous
+call site — the common case, based on the two `<example>` blocks already in
+the XML docs (`Console.WriteLine` vs. an async logger).
+
+## Decision
+
+Provide two overloads — `DoAsync(this IAsyncEnumerable<T>, Action<T>, ...)`
+and `DoAsync(this IAsyncEnumerable<T>, Func<T, Task>, ...)` — and let normal
+C# overload resolution pick the right one from the lambda's inferred shape.
+Both funnel into the same `DoCoreAsync` iterator pattern (one core method per
+delegate shape) so the streaming/cancellation/disposal logic isn't
+duplicated, only the per-element invocation differs.
+
+## Consequences
+
+- Both the synchronous and asynchronous call sites read naturally — no
+  `Task.CompletedTask` boilerplate, no runtime type dispatch.
+- The public surface has two `DoAsync` signatures to document and keep in
+  sync (see the two `<example>` blocks in the XML docs) instead of one — a
+  deliberate, bounded cost given the two are genuinely different execution
+  shapes.
+- Any future third variant (e.g. a `CancellationToken`-aware action,
+  `Func<T, CancellationToken, Task>`) follows the same pattern rather than
+  collapsing back into a single delegate-typed overload.

--- a/docs/adr/0003-chunkasync-returns-icollection-not-ireadonlylist.md
+++ b/docs/adr/0003-chunkasync-returns-icollection-not-ireadonlylist.md
@@ -1,0 +1,51 @@
+# ADR-0003: `ChunkAsync` returns `ICollection<T>`, not `IReadOnlyList<T>`
+
+## Status
+
+Accepted
+
+## Context
+
+`ChunkAsync` splits a stream into fixed-size batches, yielding each chunk as
+it fills. Internally, each chunk is built as a right-sized `T[]` (the
+implementation fills a working array up to `maxChunkSize`, then copies the
+final partial chunk down to its exact length rather than paying for
+`Array.Resize`'s extra bookkeeping). Arrays satisfy both `ICollection<T>`
+and `IReadOnlyList<T>`, so the declared return type is a documentation
+choice about what a consumer is entitled to rely on, not an implementation
+constraint.
+
+`IReadOnlyList<T>` would advertise positional indexing (`chunk[2]`) and
+`Count` as part of the contract. `ICollection<T>` advertises `Count` and
+enumeration, but not stable positional access. Most consumers of a chunk
+only need "how many, and iterate them" — batch-insert, bulk-send,
+`foreach`-and-process. Committing to `IReadOnlyList<T>` here would signal
+that index-based access is a supported, load-bearing pattern, and would
+narrow the door for a future internal representation (e.g. a pooled buffer
+or a struct-based span-backed chunk) that supports enumeration and `Count`
+cheaply but not O(1) indexing.
+
+## Decision
+
+`ChunkAsync` returns `IAsyncEnumerable<ICollection<T>>`. The current
+implementation happens to hand back arrays (which also satisfy
+`IReadOnlyList<T>`), but that is an implementation detail, not part of the
+public contract.
+
+## Consequences
+
+- Consumers get `Count` without an extra allocation or `ICollection<T>`'s
+  own array cast, and can enumerate — enough for the batch-processing use
+  case this method exists for.
+- A consumer that indexes into a chunk (`chunk[2]`) today will keep working
+  (arrays support it), but is relying on implementation detail beyond the
+  documented contract; a future change to the internal representation could
+  legitimately break that usage without it counting as a breaking API
+  change under this library's SemVer contract.
+- `ICollection<T>` technically also exposes `Add`/`Remove`/`Clear`. Because
+  the underlying object is an array, calling those throws
+  `NotSupportedException` at runtime rather than being prevented at compile
+  time — a known, accepted gap of `ICollection<T>` versus a true read-only
+  collection type, traded for netstandard2.0/net462 compatibility (no
+  dependency on `System.Collections.Immutable` or a custom read-only
+  wrapper type).

--- a/docs/adr/0004-banned-symbols-enforce-async-first.md
+++ b/docs/adr/0004-banned-symbols-enforce-async-first.md
@@ -1,0 +1,48 @@
+# ADR-0004: `BannedSymbols.txt` enforces async-first, not just "no blocking calls"
+
+## Status
+
+Accepted
+
+## Context
+
+A library built around `IAsyncEnumerable<T>` is only as good as its
+weakest internal shortcut. A single `.Result`, `.GetAwaiter().GetResult()`,
+or `Thread.Sleep` slipped into a helper method silently reintroduces
+thread-pool starvation and deadlock risk for every consumer, no matter how
+carefully the public async surface is designed — and a code reviewer can
+miss one call in a large diff far more easily than an automated gate can.
+
+Two enforcement options existed: rely on reviewer diligence (cheap to skip,
+easy to regress), or use the Roslyn `BannedApiAnalyzer`'s `BannedSymbols.txt`
+mechanism to fail the build on a documented denylist. The denylist approach
+was chosen and scoped deliberately wider than "the obviously blocking APIs"
+(`Task.Wait`, `.Result`) to also cover `Thread.Sleep`, synchronous
+`System.IO.File`/`Stream` members, and `Parallel.For`/`ForEach`/`Invoke` —
+APIs that are not deadlock-prone by themselves but represent a
+synchronous-first mindset this library exists to move consumers away from.
+Each banned entry carries its own reason/alternative text (visible directly
+in the analyzer diagnostic), rather than pointing at external docs.
+
+## Decision
+
+`BannedSymbols.txt` is the enforced async-first policy for this repo's own
+source, not merely a deadlock-prevention list. New entries are added
+whenever a synchronous alternative to an async-capable API would tempt a
+future contributor to reach for the easy synchronous path inside this
+library's implementation.
+
+## Consequences
+
+- A contributor who reaches for `Thread.Sleep` or `Parallel.ForEach` inside
+  `IAsyncEnumerableExtensions.cs` gets a build error with the async
+  replacement named inline, instead of a design smell that only a careful
+  reviewer would catch.
+- The list is necessarily broader than "things that can deadlock," so it
+  will occasionally flag an API that would have been *safe* in a specific
+  context (e.g. a genuinely CPU-bound, non-blocking use of
+  `Parallel.For`). Bulk analysis contexts should file the exception rather
+  than remove the entry.
+- The list only governs this repository's own implementation code — it says
+  nothing about what a *consumer* of the published NuGet package chooses to
+  do in their own code.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,20 @@
+# ADR-NNNN: Title
+
+## Status
+
+Proposed | Accepted | Superseded by [ADR-NNNN](NNNN-title.md) | Deprecated
+
+## Context
+
+What forces are at play — the problem, the constraints, the alternatives that
+were on the table. Written so a reader unfamiliar with the discussion can
+follow the reasoning, not just the outcome.
+
+## Decision
+
+What was decided, stated as a single clear sentence if possible.
+
+## Consequences
+
+What becomes easier or harder as a result. Include the trade-offs that were
+accepted, not just the benefits.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-pin-assemblyversion-to-1.0.0.0.md) | Pin AssemblyVersion to a fixed 1.0.0.0 baseline | Accepted |
+| [0002](0002-two-doasync-overloads-instead-of-one.md) | Two `DoAsync` overloads instead of a single merged one | Accepted |
+| [0003](0003-chunkasync-returns-icollection-not-ireadonlylist.md) | `ChunkAsync` returns `ICollection<T>`, not `IReadOnlyList<T>` | Accepted |
+| [0004](0004-banned-symbols-enforce-async-first.md) | `BannedSymbols.txt` enforces async-first, not just "no blocking calls" | Accepted |
+
+New ADRs land alongside the PR that introduces the corresponding decision —
+see [TEMPLATE.md](TEMPLATE.md).


### PR DESCRIPTION
## Summary
- `docs/adr/TEMPLATE.md` + `docs/adr/index.md` establish the ADR convention per #245.
- Four retroactive ADRs for this repo's non-obvious existing choices:
  - **ADR-0001**: why `AssemblyVersion` is pinned at `1.0.0.0` (binding-stability baseline)
  - **ADR-0002**: why `DoAsync` has two overloads (`Action<T>` / `Func<T, Task>`) instead of one merged signature
  - **ADR-0003**: why `ChunkAsync` returns `ICollection<T>`, not `IReadOnlyList<T>`
  - **ADR-0004**: why `BannedSymbols.txt` is scoped as an async-first policy, not just a deadlock-prevention list

Closes #245

Part of the thorough-review campaign — targets `vNext`.