### PR TITLE
ci: adopt OSSF Scorecard automated security-posture scoring

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,47 @@
+name: "OSSF Scorecard"
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'  # Weekly on Saturday at 01:30 UTC
+  push:
+    branches: [ "main" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: "Scorecard analysis"
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the public OSSF Scorecard API/badge service
+          # (this is a public open-source repo).
+          publish_results: true
+
+      - name: Upload SARIF results as an artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload results to code-scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `scorecard.yaml`: weekly + push-to-main OSSF Scorecard scan, SARIF
+  uploaded to the Security tab, badge added to `README.md`, 7.5 score
+  floor documented in `SECURITY.md` (#247).
+
 ## [0.5.2] - 2026-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A collection of extension methods for `IAsyncEnumerable<T>` in .NET — chunking
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,20 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## OSSF Scorecard
+
+[`scorecard.yaml`](.github/workflows/scorecard.yaml) runs the
+[OSSF Scorecard](https://github.com/ossf/scorecard) weekly and on every push
+to `main`, scoring this repo's security posture (branch protection, pinned
+dependencies, dangerous-workflow patterns, vulnerability response time,
+etc.) against the project's checks. Results publish to the
+[Scorecard viewer](https://securityscorecards.dev/viewer/?uri=github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions)
+and the badge in `README.md`, and upload as SARIF to this repo's Security
+tab alongside CodeQL alerts.
+
+**Score floor: 7.5.** The initial baseline score is whatever the first
+scheduled run reports — there was no prior run to snapshot before this
+workflow existed. If a later run drops the score below 7.5, note it in
+`CHANGELOG.md` under `### Security` and open a maintenance issue for the
+regressed check; don't let it sit unaddressed.


### PR DESCRIPTION
## Summary
- `scorecard.yaml`: OSSF Scorecard runs weekly + on push to `main`, results published to the public Scorecard viewer and uploaded as SARIF to this repo's Security tab (alongside CodeQL).
- README badge added.
- `SECURITY.md`: documented 7.5 score-floor policy — a regression below floor gets a CHANGELOG note + a maintenance issue.
- All actions SHA-pinned with full-version comments per fleet convention.

Closes #247

Part of the thorough-review campaign — targets `vNext`.