### PR TITLE
ci: add zizmor + actionlint workflow security audit

### DIFF
--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,65 @@
+name: "Workflow Security Audit"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.zizmor.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.zizmor.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: "zizmor"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          config: .zizmor.yml
+          # SARIF uploads to the Security tab (same pattern as CodeQL/Scorecard)
+          # so findings persist across pushes instead of only living in job logs.
+          advanced-security: true
+
+  actionlint:
+    name: "actionlint"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1.73.2
+        with:
+          reporter: github-pr-review
+          fail_level: error

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,12 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# Suppression baseline. Add an entry only after triaging a finding as an
+# accepted risk (not a false positive you can just fix) and record why.
+# Prefer a same-line `# zizmor: ignore[rule-id]` comment in the workflow
+# file itself for a single finding — reserve this file for repo-wide rule
+# exclusions.
+#
+# rules:
+#   some-rule-id:
+#     ignore:
+#       - workflow.yml  # reason this specific instance is accepted risk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `workflow-security.yaml`: zizmor + actionlint run on any PR/push touching
+  `.github/workflows/**`, catching workflow-level vulnerabilities (untrusted
+  `run:`-block injection, missing `permissions:`, unpinned actions) that
+  CodeQL doesn't inspect. zizmor findings upload as SARIF to the Security
+  tab; actionlint posts inline PR review comments and fails on `error`.
+  `.zizmor.yml` holds the repo-wide suppression baseline. Documented in
+  `docs/WORKFLOW_SECURITY.md` (#248).
+
 ## [0.5.2] - 2026-07-06
 
 ### Changed

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -176,6 +176,29 @@ When adding new configuration files that control code quality or security:
 3. Test that the file is correctly fetched from main branch.
 4. Update this documentation.
 
+## Workflow-file static analysis
+
+CodeQL (`codeql.yaml`) scans this repo's C# source. It does not inspect the
+GitHub Actions YAML itself for workflow-level vulnerabilities. That's
+`workflow-security.yaml`'s job — it runs on any PR or push to `main` that
+touches `.github/workflows/**` or `.zizmor.yml`:
+
+- **[zizmor](https://github.com/zizmorcore/zizmor)** — untrusted-input
+  injection into `run:` blocks, missing/overly-permissive `permissions:`,
+  secret leakage via expression-context expansion, unpinned third-party
+  actions. Findings upload as SARIF to the Security tab, same as CodeQL.
+  Repo-wide suppressions with a documented reason live in `.zizmor.yml`;
+  a single-finding exception can instead use an inline
+  `# zizmor: ignore[rule-id]` comment in the workflow file.
+- **[actionlint](https://github.com/rhysd/actionlint)** — YAML/expression
+  syntax errors, invalid `uses:` refs, shellcheck issues inside `run:`
+  blocks. Reported as inline PR review comments via reviewdog; a new
+  `error`-level finding fails the check.
+
+Because this workflow itself lives under `.github/workflows/`, it is a
+protected configuration file (see above) — a PR that adds or edits it will
+be flagged for manual review when merging into `main`.
+
 ## References
 
 - [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)


### PR DESCRIPTION
## Summary
- `workflow-security.yaml`: runs on any PR/push touching `.github/workflows/**` or `.zizmor.yml`.
- **zizmor** — workflow-level vulnerabilities (untrusted `run:`-block injection, missing/overly-permissive `permissions:`, secret leakage, unpinned actions) that CodeQL doesn't inspect. Findings upload as SARIF to the Security tab.
- **actionlint** — YAML/expression syntax + shellcheck issues, reported as inline PR review comments via reviewdog, fails on `error`.
- `.zizmor.yml` holds the repo-wide suppression baseline (empty — nothing triaged yet).
- Documented in `docs/WORKFLOW_SECURITY.md`.

Closes #248

Part of the thorough-review campaign — targets `vNext`. Note: since this workflow itself lives under `.github/workflows/`, it'll need the protected-file-pr-split treatment when vNext eventually merges to main.