### PR TITLE
test: add Native AOT / trim compatibility smoke test

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,49 @@
+name: "AOT/Trim Smoke Test"
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  aot-smoke:
+    name: "Native AOT publish + run (linux-x64)"
+    # Native AOT can only be published on the target OS — Windows can't
+    # cross-publish linux-x64 AOT, hence a dedicated Linux job rather than
+    # folding this into pr.yaml's Windows/macOS stages.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish AotSmoke (linux-x64, AOT + trimmed)
+        run: >
+          dotnet publish tests/AotSmoke/AotSmoke.csproj
+          --configuration Release
+          --runtime linux-x64
+          --self-contained true
+          --output ./aot-smoke-publish
+
+      - name: Run the published AOT binary
+        run: ./aot-smoke-publish/AotSmoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `tests/AotSmoke`: Native AOT / trim compatibility smoke test. A console
+  consumer exercises every public method on `IAsyncEnumerableExtensions`
+  and asserts real results; `aot-smoke.yaml` publishes it
+  `PublishAot`+`PublishTrimmed` on linux-x64 and runs it, so a trimmed
+  member fails the check instead of silently no-opping. This library has
+  no reflection or `Expression.Compile`, so no trim-safety annotations
+  were needed (#238).
+
 ### Changed
 
 ### Deprecated

--- a/tests/AotSmoke/AotSmoke.csproj
+++ b/tests/AotSmoke/AotSmoke.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<InvariantGlobalization>true</InvariantGlobalization>
+		<PublishAot>true</PublishAot>
+		<PublishTrimmed>true</PublishTrimmed>
+		<IsPackable>false</IsPackable>
+		<!-- Throwaway AOT smoke harness — not shipped, not held to the
+		     strict warnings-as-errors bar the shipped library is held to.
+		     Directory.Build.props still applies TWAE in Release regardless
+		     of .slnx membership (it's a directory-walk-up import, not a
+		     solution-membership rule), so this is an explicit opt-out. -->
+		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IAsyncEnumerable\Wolfgang.Extensions.IAsyncEnumerable.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/tests/AotSmoke/Program.cs
+++ b/tests/AotSmoke/Program.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Extensions.IAsyncEnumerable;
+
+// Native-AOT / trim smoke test (#238). Exercises every public method on
+// IAsyncEnumerableExtensions under a PublishAot + PublishTrimmed publish and
+// asserts real results, so a trimmed member shows up as a non-zero exit
+// instead of a silent no-op. This library has no reflection, no
+// Expression.Compile, and no attribute-driven mapping — unlike the ETL
+// family's reflection-based mappers, no [DynamicallyAccessedMembers] /
+// TrimmerRootAssembly should be necessary here. The smoke exists to prove
+// that, not assume it.
+
+var failures = new List<string>();
+
+await CheckAsync("ChunkAsync", async () =>
+{
+    var chunks = new List<int[]>();
+    await foreach (var chunk in Range(1, 10).ChunkAsync(3))
+    {
+        chunks.Add(chunk.ToArray());
+    }
+
+    Assert(chunks.Count == 4, $"expected 4 chunks, got {chunks.Count}");
+    Assert(chunks[0].SequenceEqual([1, 2, 3]), "chunk 0 mismatch");
+    Assert(chunks[3].SequenceEqual([10]), "final partial chunk mismatch");
+});
+
+await CheckAsync("DoAsync(Action<T>)", async () =>
+{
+    var seen = new List<int>();
+    var yielded = new List<int>();
+    await foreach (var item in Range(1, 5).DoAsync(x => seen.Add(x)))
+    {
+        yielded.Add(item);
+    }
+
+    Assert(seen.SequenceEqual(yielded), "DoAsync(Action<T>) side-effect/yield mismatch");
+    Assert(yielded.SequenceEqual([1, 2, 3, 4, 5]), "DoAsync(Action<T>) yielded wrong sequence");
+});
+
+await CheckAsync("DoAsync(Func<T, Task>)", async () =>
+{
+    var seen = new List<int>();
+    await foreach (var item in Range(1, 5).DoAsync(async x =>
+                   {
+                       await Task.Yield();
+                       seen.Add(x);
+                   }))
+    {
+        _ = item;
+    }
+
+    Assert(seen.SequenceEqual([1, 2, 3, 4, 5]), "DoAsync(Func<T, Task>) side-effect mismatch");
+});
+
+await CheckAsync("ForEachAsync(Action<T>)", async () =>
+{
+    var sum = 0;
+    await Range(1, 5).ForEachAsync(x => sum += x);
+    Assert(sum == 15, $"expected sum 15, got {sum}");
+});
+
+await CheckAsync("ForEachAsync(Func<T, Task>)", async () =>
+{
+    var sum = 0;
+    await Range(1, 5).ForEachAsync(async x =>
+    {
+        await Task.Yield();
+        sum += x;
+    });
+    Assert(sum == 15, $"expected sum 15, got {sum}");
+});
+
+await CheckAsync("IsEmptyAsync", async () =>
+{
+    Assert(await Range(0, 0).IsEmptyAsync(), "empty source should report IsEmptyAsync == true");
+    Assert(!await Range(1, 1).IsEmptyAsync(), "non-empty source should report IsEmptyAsync == false");
+});
+
+await CheckAsync("IsNullOrEmptyAsync", async () =>
+{
+    IAsyncEnumerable<int>? nullSource = null;
+    Assert(await nullSource.IsNullOrEmptyAsync(), "null source should report IsNullOrEmptyAsync == true");
+    Assert(await Range(0, 0).IsNullOrEmptyAsync(), "empty source should report IsNullOrEmptyAsync == true");
+    Assert(!await Range(1, 1).IsNullOrEmptyAsync(), "non-empty source should report IsNullOrEmptyAsync == false");
+});
+
+await CheckAsync("NoneAsync()", async () =>
+{
+    Assert(await Range(0, 0).NoneAsync(), "empty source should report NoneAsync() == true");
+    Assert(!await Range(1, 1).NoneAsync(), "non-empty source should report NoneAsync() == false");
+});
+
+await CheckAsync("NoneAsync(predicate)", async () =>
+{
+    Assert(await Range(1, 5).NoneAsync(x => x > 100), "no element satisfies x > 100");
+    Assert(!await Range(1, 5).NoneAsync(x => x == 3), "element 3 satisfies the predicate");
+});
+
+if (failures.Count > 0)
+{
+    Console.Error.WriteLine($"AOT smoke FAILED ({failures.Count} check(s)):");
+    foreach (var failure in failures)
+    {
+        Console.Error.WriteLine($"  - {failure}");
+    }
+
+    return 1;
+}
+
+Console.WriteLine("AOT smoke OK — all public methods verified under PublishAot + PublishTrimmed.");
+return 0;
+
+async Task CheckAsync(string name, Func<Task> check)
+{
+    try
+    {
+        await check();
+        Console.WriteLine($"  [ok] {name}");
+    }
+    catch (Exception ex)
+    {
+        failures.Add($"{name}: {ex.Message}");
+        Console.Error.WriteLine($"  [FAIL] {name}: {ex.Message}");
+    }
+}
+
+void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}
+
+static async IAsyncEnumerable<int> Range(int start, int count)
+{
+    for (var i = 0; i < count; i++)
+    {
+        await Task.Yield();
+        yield return start + i;
+    }
+}


### PR DESCRIPTION
## Summary
- `tests/AotSmoke`: console consumer exercises every public method on `IAsyncEnumerableExtensions` (`ChunkAsync`, `DoAsync` × 2, `ForEachAsync` × 2, `IsEmptyAsync`, `IsNullOrEmptyAsync`, `NoneAsync` × 2) and asserts real results — a trimmed member fails the check instead of silently no-opping.
- `aot-smoke.yaml`: publishes it `PublishAot`+`PublishTrimmed` on `linux-x64` and runs the binary. Windows can't cross-publish Native AOT for linux-x64, hence a dedicated Linux job rather than folding into `pr.yaml`'s existing stages.
- Verified locally via `dotnet run` (JIT) — all 9 checks pass. The actual AOT publish can only be verified on Linux CI (will run once this PR/vNext gets CI attention — note `pr.yaml`/`aot-smoke.yaml` only trigger on PRs targeting `main`, so this validates for real once vNext merges).
- This library has no reflection or `Expression.Compile`, unlike the ETL family's reflection-based mappers — no trim-safety annotations were needed. The smoke exists to *prove* that, not assume it.
- Kept out of `.slnx`; `TreatWarningsAsErrors` explicitly disabled in the project itself (Directory.Build.props applies via directory walk-up regardless of solution membership, so `.slnx` exclusion alone doesn't skip TWAE for a direct `dotnet publish`).

Closes #238

Part of the thorough-review campaign — targets `vNext`.