### PR TITLE
docs: document allocation policy (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/ALLOCATION-POLICY.md`: documents that no public method is
+  zero-alloc by design (every method is an async/iterator state
+  machine, and `ChunkAsync`'s array allocation is its whole point), and
+  points to the existing `[MemoryDiagnoser]` BDN trend as the ongoing
+  allocation-regression signal instead of a half-implemented zero-byte
+  gate (#242).
+
 ### Changed
 
 ### Deprecated

--- a/docs/ALLOCATION-POLICY.md
+++ b/docs/ALLOCATION-POLICY.md
@@ -1,0 +1,41 @@
+# Allocation policy
+
+## No public method is documented as zero-allocation
+
+Every method on `IAsyncEnumerableExtensions` either compiles to an `async`
+state machine (`DoAsync`, `ForEachAsync`, `IsEmptyAsync`,
+`IsNullOrEmptyAsync`, `NoneAsync`) or an async-iterator state machine
+(`ChunkAsync`'s `ChunkCoreAsync`, `DoAsync`'s `DoCoreAsync`) — both allocate
+a heap-based state-machine object on `netstandard2.0`/`net462` by design
+(the .NET runtime does not stack-allocate async/iterator state machines on
+those TFMs). `ChunkAsync` additionally allocates a right-sized `T[]` per
+chunk — that allocation is the method's entire purpose, not a hot-path
+regression to eliminate.
+
+Given that, an opt-in `[NoAlloc]`/zero-byte-assertion test suite (the shape
+`#242` originally asked for) would either assert something already false
+by design, or exclude every method from the check — a check with nothing
+left to check isn't worth the maintenance weight. This is the documented
+"skip" outcome `#242` itself allows for: *"Skip on libraries where no
+method is intended to be zero-alloc (snapshot doc explaining why instead
+of half-implemented enforcement)."* This file is that snapshot.
+
+## What's already in place instead
+
+`[MemoryDiagnoser]` is enabled on every `BenchmarkDotNet` benchmark class
+under `benchmarks/` (one per public method — see
+`ChunkAsyncBenchmarks.cs`, `DoAsyncBenchmarks.cs`, `ForEachAsyncBenchmarks.cs`,
+`EmptyCheckAsyncBenchmarks.cs`, `NoneAsyncBenchmarks.cs`). `benchmarks.yaml`
+runs the full suite on every push to `main` and publishes results to the
+`gh-pages` trend chart, so a *regression* in bytes-allocated-per-call is
+visible over time for every method, even without a hard zero-byte gate.
+That's the right level of enforcement here: catch "this got worse," don't
+assert "this is exactly zero" for methods that were never meant to be.
+
+## If a future method needs a real zero-alloc guarantee
+
+If a future addition to this library is specifically designed to avoid
+allocating (e.g. a pooled-buffer variant), document that method's
+allocation contract in its XML doc `<remarks>` and add a targeted
+`GC.GetAllocatedBytesForCurrentThread()` assertion scoped to that one
+method — don't generalize it back to the whole public surface.


### PR DESCRIPTION
## Summary
- `docs/ALLOCATION-POLICY.md`: every public method is an async/iterator state machine by construction (heap-allocates on netstandard2.0/net462 by .NET design) and `ChunkAsync`'s array allocation is its entire purpose — there's no method here that's meant to be zero-alloc.
- Rather than build a zero-byte-assertion suite that would either assert something false-by-design or have nothing left to check, this documents the existing `[MemoryDiagnoser]` BDN benchmarks (already present, one per method) + `benchmarks.yaml`'s gh-pages trend chart as the actual allocation-regression signal.
- This is the "skip" outcome #242 itself allows for: *"Skip on libraries where no method is intended to be zero-alloc (snapshot doc explaining why instead of half-implemented enforcement)."*

Closes #242

Part of the thorough-review campaign — targets `vNext`.