### PR TITLE
fix(tests): kill the 5 surviving cancellation-guard mutants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ChunkAsyncTests`, `DoAsyncTests`, `ForEachAsyncTests`: 5 new tests isolating
+  each pre-loop `ThrowIfCancellationRequested()` guard from the matching
+  in-loop check, killing the 5 Stryker survivors tracked in #304. The
+  existing pre-canceled-token tests drained the whole sequence, so a
+  pre-canceled token also tripped the in-loop check on the second
+  `MoveNextAsync()` — masking a removed pre-loop check. The new tests assert
+  on the very first `MoveNextAsync()`/action invocation instead, so the
+  source is provably never touched. Mutation score: 92.06% → 100%, 0
+  survivors (#304).
+
 ### Changed
 
 ### Deprecated

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ChunkAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ChunkAsyncTests.cs
@@ -122,6 +122,30 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
+    public async Task ChunkAsync_WithPreCanceledToken_NeverEnumeratesSource()
+    {
+        // The pre-loop ThrowIfCancellationRequested() must fire before the source is
+        // ever touched. A source with enough items to fill a full chunk would otherwise
+        // let the in-loop check (after the first yield) catch the same pre-canceled
+        // token, masking a removed pre-loop check.
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var source = new TrackingAsyncEnumerable(1, 2, 3);
+
+        var chunked = source.ChunkAsync(2, tokenSource.Token);
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            async () => await chunked.GetAsyncEnumerator().MoveNextAsync()
+        );
+
+        Assert.False(source.EnumerationStarted);
+    }
+
+
+
+    [Fact]
     public async Task ChunkAsync_WhenCancellationRequestedDuringEnumeration_ThrowsOperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DoAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DoAsyncTests.cs
@@ -115,6 +115,30 @@ public sealed class DoAsyncTests
 
 
     [Fact]
+    public async Task DoAsync_Action_with_pre_canceled_token_never_enumerates_source()
+    {
+        // The pre-loop ThrowIfCancellationRequested() must fire on the very first
+        // MoveNextAsync() call, before the source is touched. Draining the whole
+        // sequence would instead hit the in-loop check after the first yield, which
+        // fires on this same pre-canceled token regardless of the pre-loop check.
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var source = new TrackingAsyncEnumerable(1, 2, 3);
+
+        var tapped = source.DoAsync(_ => { }, tokenSource.Token);
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            async () => await tapped.GetAsyncEnumerator().MoveNextAsync()
+        );
+
+        Assert.False(source.EnumerationStarted);
+    }
+
+
+
+    [Fact]
     public async Task DoAsync_Action_when_cancellation_requested_during_enumeration_throws_OperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();
@@ -296,6 +320,29 @@ public sealed class DoAsyncTests
         (
             () => CollectAsync(source.DoAsync(_ => Task.CompletedTask, tokenSource.Token))
         );
+    }
+
+
+
+    [Fact]
+    public async Task DoAsync_Func_with_pre_canceled_token_never_enumerates_source()
+    {
+        // Same isolation as the Action overload's pre-loop check: assert on the very
+        // first MoveNextAsync() call rather than draining the sequence, so the
+        // in-loop check (after the first yield) can't mask a removed pre-loop check.
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var source = new TrackingAsyncEnumerable(1, 2, 3);
+
+        var tapped = source.DoAsync(_ => Task.CompletedTask, tokenSource.Token);
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            async () => await tapped.GetAsyncEnumerator().MoveNextAsync()
+        );
+
+        Assert.False(source.EnumerationStarted);
     }
 
 

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ForEachAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ForEachAsyncTests.cs
@@ -84,6 +84,29 @@ public sealed class ForEachAsyncTests
 
 
     [Fact]
+    public async Task ForEachAsync_Action_with_pre_canceled_token_never_invokes_action()
+    {
+        // The pre-loop ThrowIfCancellationRequested() must fire before the source is
+        // ever enumerated. Asserting only the exception type would still pass if that
+        // check were removed, since the in-loop check (after the first action call)
+        // fires on this same pre-canceled token — so assert the action never ran too.
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var source = CreateSource(1, 2, 3);
+        var invoked = false;
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            () => source.ForEachAsync(_ => invoked = true, tokenSource.Token)
+        );
+
+        Assert.False(invoked);
+    }
+
+
+
+    [Fact]
     public async Task ForEachAsync_Action_when_cancellation_requested_during_enumeration_throws_OperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();
@@ -221,6 +244,31 @@ public sealed class ForEachAsyncTests
         (
             () => source.ForEachAsync(_ => Task.CompletedTask, tokenSource.Token)
         );
+    }
+
+
+
+    [Fact]
+    public async Task ForEachAsync_Func_with_pre_canceled_token_never_invokes_action()
+    {
+        // Same isolation as the Action overload's pre-loop check — assert the async
+        // action never ran, not just that some OperationCanceledException surfaced.
+        using var tokenSource = new CancellationTokenSource();
+        tokenSource.Cancel();
+
+        var source = CreateSource(1, 2, 3);
+        var invoked = false;
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            () => source.ForEachAsync(_ =>
+            {
+                invoked = true;
+                return Task.CompletedTask;
+            }, tokenSource.Token)
+        );
+
+        Assert.False(invoked);
     }
 
 


### PR DESCRIPTION
Closes #304

## Summary
Each surviving mutant removed a pre-loop `ThrowIfCancellationRequested()` guard. The existing pre-canceled-token tests drained the whole sequence, so the in-loop check (right after the first yield) also fired on the same pre-canceled token — masking a removed pre-loop check.

Added 5 tests across `ChunkAsyncTests`, `DoAsyncTests`, `ForEachAsyncTests` that assert on the very first `MoveNextAsync()`/action invocation instead of draining the sequence, isolating each pre-loop guard from its in-loop sibling.

## Verification
- `dotnet test` (net10.0): 135 passed (130 + 5 new)
- `dotnet stryker`: **100.00%** mutation score, 0 survivors (was 92.06% / 5 survivors)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>