### PR TITLE
feat(ci): add InspectCode noise-floor .DotSettings profile

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -208,7 +208,7 @@ jobs:
           # — a silent deletion is just as security-relevant as a silent edit.
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRCD main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset|DotSettings)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the very first `MoveNextAsync()`/action invocation instead, so the
   source is provably never touched. Mutation score: 92.06% → 100%, 0
   survivors (#304).
+- `IAsyncEnumerable Extensions.slnx.DotSettings`: ReSharper InspectCode
+  noise-floor profile, silencing the `RS0016`/`RS0036`/`RS0037`
+  (PublicApiAnalyzer) findings InspectCode duplicates from this repo's own
+  PublicApiAnalyzer gate. Dropped InspectCode's findings on a clean main
+  from 349 to 40, with no change to the error-only merge gate (all 349 were
+  already warning-severity). `*.DotSettings` added to `pr.yaml`'s protected
+  configuration files, closing the gap where a PR could edit it without
+  triggering the maintainer-review guard (#266).
 
 ### Changed
 

--- a/IAsyncEnumerable Extensions.slnx.DotSettings
+++ b/IAsyncEnumerable Extensions.slnx.DotSettings
@@ -1,0 +1,25 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<!--
+	Noise-floor profile for the "ReSharper InspectCode" required check (#266).
+
+	RS0016/RS0036/RS0037 are Microsoft.CodeAnalysis.PublicApiAnalyzers rules —
+	this repo's own PublicApiAnalyzer package already gates the exact same
+	findings at build time via PublicAPI.Shipped.txt/PublicAPI.Unshipped.txt.
+	InspectCode bundles the same analyzer and re-reports every finding a
+	second time, so leaving these enabled here is pure duplicate noise, not
+	an additional signal. Confirmed locally: these three IDs accounted for
+	300 of 349 total InspectCode findings on a clean main.
+
+	Everything else stays at its default severity — those are genuine
+	InspectCode-only findings (dead code, redundant casts, possible multiple
+	enumeration, etc.) not covered by any other analyzer in the pipeline, and
+	are visible in Security → Code scanning at warning severity without
+	failing the build. Address them incrementally; only raise this job's gate
+	from error-only to warning-inclusive once that backlog is clear.
+	-->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0016/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0036/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0037/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+</wpf:ResourceDictionary>

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -41,6 +41,7 @@ A malicious PR could modify these files to disable security checks.
 - `BannedSymbols.txt` - Banned API usage rules
 - `*.globalconfig` - Global analyzer configuration
 - `*.ruleset` - Code analysis rulesets
+- `*.DotSettings` - ReSharper InspectCode noise-floor profile
 - `.github/workflows/*.yml` and `.github/workflows/*.yaml` - Workflow definitions
 
 In addition to the overwrite step, a separate "Detect protected configuration file changes" step in `pr.yaml` causes the PR to fail if any of these files differ from `main`, signalling that a maintainer must manually review the change. Dependabot is exempted (its bumps to `Directory.Build.props` are legitimate).
@@ -62,6 +63,7 @@ In addition to the overwrite step, a separate "Detect protected configuration fi
       "BannedSymbols.txt"
       "*.globalconfig"
       "*.ruleset"
+      "*.DotSettings"
       ".github/workflows/*.yml"
       ".github/workflows/*.yaml"
     )


### PR DESCRIPTION
Part of #266 (the remaining two acceptance criteria — required-check ruleset addition is a separate manual step, see below).

## Summary
- Added `IAsyncEnumerable Extensions.slnx.DotSettings` silencing `RS0016`/`RS0036`/`RS0037` — these are PublicApiAnalyzer findings InspectCode duplicates from this repo's own PublicApiAnalyzer build-time gate. Confirmed locally: 300 of 349 total findings on a clean main were these three IDs.
- Added `*.DotSettings` to `pr.yaml`'s "Detect protected configuration file changes" guard — it was already fetched-from-main but not flagged for maintainer review if a PR edited it directly, per `docs/WORKFLOW_SECURITY.md`'s own documented procedure for adding a new protected file.
- Updated `docs/WORKFLOW_SECURITY.md`'s protected-file list to match.

## Verification
Ran `jb inspectcode` locally before/after: 349 → 40 findings, all still warning-severity (0 errors before and after — the job's merge gate is unaffected either way).

## Not done here
"ReSharper InspectCode" → main's required-status-checks ruleset is a repo-settings change the harness blocked me from making directly. Command for Chris to run:
```
gh api -X PUT repos/Chris-Wolfgang/IAsyncEnumerable-Extensions/rulesets/14654058 --input <payload>
```
(payload adds `{"context": "ReSharper InspectCode"}` to the existing required_status_checks list, everything else unchanged)

Also worth flagging: the `main` ruleset is currently `enforcement: disabled` (as of this morning) — separate from this PR, but worth re-enabling once any admin-bypass work for this cycle is done.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>