### PR TITLE
feat: add PackageValidation gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already warning-severity). `*.DotSettings` added to `pr.yaml`'s protected
   configuration files, closing the gap where a PR could edit it without
   triggering the maintainer-review guard (#266).
+- `EnablePackageValidation` + `PackageValidationBaselineVersion` (0.5.3) on
+  the src csproj — protects consumers against an unintentional
+  binary-breaking change at the next release. Verified locally: `dotnet
+  pack` reports zero compatibility breaks against the published 0.5.3
+  baseline (#286).
 
 ### Changed
 

--- a/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
@@ -19,6 +19,8 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<EnablePackageValidation>True</EnablePackageValidation>
+		<PackageValidationBaselineVersion>0.5.3</PackageValidationBaselineVersion>
 		<SignAssembly>False</SignAssembly>
 		<ApplicationIcon>icon.ico</ApplicationIcon>
 		<PackageIcon>icon_128x128.png</PackageIcon>


### PR DESCRIPTION
Closes #286

## Summary
This repo had no `PackageValidation`, leaving consumers unprotected against an unintentional binary-breaking change at the next release — every other repo in the fleet has this gate.

Added `EnablePackageValidation` + `PackageValidationBaselineVersion` (0.5.3, latest published) to the src csproj.

## Verification
`dotnet pack -c Release` reports zero compatibility breaks against the 0.5.3 baseline (0.5.3 is confirmed live on the NuGet flatcontainer CDN).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>