### PR TITLE
docs(security): add release-path & compromise-scope appendix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `SECURITY.md`: added a "Release path & compromise scope" appendix
+  documenting the OIDC release identity, the (nonexistent) fallback if
+  Trusted Publishing is compromised, and the package coordinates for
+  unlisting — the load-bearing facts a maintainer would need during an
+  incident, without duplicating GitHub's/NuGet's own generic
+  incident-response docs (#246).
+
 ## [0.5.3] - 2026-08-26
 
 No public API changes. This release is a maintenance / infrastructure

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,3 +66,13 @@ scheduled run reports — there was no prior run to snapshot before this
 workflow existed. If a later run drops the score below 7.5, note it in
 `CHANGELOG.md` under `### Security` and open a maintenance issue for the
 regressed check; don't let it sit unaddressed.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/IAsyncEnumerable-Extensions`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: none known within the Wolfgang.* fleet; unknown external consumers may exist on nuget.org.
+- **Package coordinates for unlisting**: `Wolfgang.Extensions.IAsyncEnumerable` — https://www.nuget.org/packages/Wolfgang.Extensions.IAsyncEnumerable/.


### PR DESCRIPTION
Closes #246

## Summary
Canonical shape from Etl-DbClient #240. All 5 bullets filled in for this repo — OIDC release path (depends on #279, this PR is stacked on top of it), no fallback path, owner, no known fleet downstream consumers (confirmed via org-wide code search — no other Wolfgang.* repo references this package), and the package's nuget.org coordinates for unlisting.

Docs-only, no version bump.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>