### PR TITLE
chore(pack): advance PackageValidation baseline to 0.5.4

### DIFF
--- a/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
@@ -20,7 +20,7 @@
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<EnablePackageValidation>True</EnablePackageValidation>
-		<PackageValidationBaselineVersion>0.5.3</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>0.5.4</PackageValidationBaselineVersion>
 		<SignAssembly>False</SignAssembly>
 		<ApplicationIcon>icon.ico</ApplicationIcon>
 		<PackageIcon>icon_128x128.png</PackageIcon>


### PR DESCRIPTION
## Summary
Bumps `PackageValidationBaselineVersion` 0.5.3 → 0.5.4, the standard post-deploy follow-up now that the NuGet flatcontainer CDN has indexed v0.5.4 (confirmed via polling before opening this PR).

## Verification
- CDN indexing: confirmed — `https://api.nuget.org/v3-flatcontainer/wolfgang.extensions.iasyncenumerable/index.json` lists `0.5.4`
- `dotnet pack -c Release`: succeeds locally, zero compatibility breaks against the new baseline
- `PublicAPI.Unshipped.txt`: no straggling entries to fold

## Post-release checklist (this PR closes it out)
- [x] `release.yaml` succeeded end-to-end (Validate → Pack → Docs → Publish → Attach Artifacts), including the OIDC publish
- [x] NuGet CDN indexed 0.5.4
- [x] Docs deployed to gh-pages (`versions/v0.5.4/` present, `versions.json` updated)
- [x] Branches pruned (local + remote — remote was already clean via auto-delete-on-merge)
- [x] `vNext` recreated fresh from `main` for the next cycle
- [x] Ruleset enforcement re-enabled (was disabled during this cycle's admin-bypass work)
- [x] Resolved issues closed: #246, #266, #279, #286, #292, #304
- [x] Evergreen umbrella #174 updated with a drive-down summary, left open

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>