### PR TITLE
Code-review fixes: test quality, dead code, shared test sources

### DIFF
--- a/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/ChunkAsyncBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/ChunkAsyncBenchmarks.cs
@@ -36,12 +36,6 @@ public class ChunkAsyncBenchmarks
 
 
 
-    //[Benchmark]
-    //public async Task<int> ChunkAsyncV2()
-    //    => await ConsumeAsync(static (source, size, token) => source.ChunkAsyncV2(size, token));
-
-
-
     private async Task<int> ConsumeAsync
     (
         Func<IAsyncEnumerable<int>, int, CancellationToken, IAsyncEnumerable<ICollection<int>>> chunker

--- a/examples/NoneAsync.Example/Program.cs
+++ b/examples/NoneAsync.Example/Program.cs
@@ -18,8 +18,6 @@ Console.WriteLine($"Populated stream has none: {await populatedStream.NoneAsync(
 Console.WriteLine();
 
 // NoneAsync(predicate) — check if no elements match
-var numbers = GenerateNumbers(10);
-
 Console.WriteLine($"None divisible by 3: {await GenerateNumbers(10).NoneAsync(n => n % 3 == 0)}");
 Console.WriteLine($"None greater than 100: {await GenerateNumbers(10).NoneAsync(n => n > 100)}");
 Console.WriteLine($"None negative: {await GenerateNumbers(10).NoneAsync(n => n < 0)}");

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/AnyAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/AnyAsyncTests.cs
@@ -1,4 +1,4 @@
-namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+namespace Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit;
 
 public sealed class AnyAsyncTests
 {
@@ -18,7 +18,7 @@ public sealed class AnyAsyncTests
     [Fact]
     public async Task AnyAsync_when_source_is_empty_returns_false()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var result = await source.AnyAsync();
 
@@ -30,11 +30,25 @@ public sealed class AnyAsyncTests
     [Fact]
     public async Task AnyAsync_when_source_has_items_returns_true()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         var result = await source.AnyAsync();
 
         Assert.True(result);
+    }
+
+
+
+    [Fact]
+    public async Task AnyAsync_only_enumerates_first_item()
+    {
+        var enumerated = new List<int>();
+        var source = TestSources.CreateTracking(enumerated, 1, 2, 3, 4, 5);
+
+        var result = await source.AnyAsync();
+
+        Assert.True(result);
+        Assert.Equal([1], enumerated);
     }
 
 
@@ -45,7 +59,7 @@ public sealed class AnyAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -71,7 +85,7 @@ public sealed class AnyAsyncTests
     [Fact]
     public async Task AnyAsync_predicate_when_predicate_is_null_throws_ArgumentNullException()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<ArgumentNullException>
         (
@@ -81,38 +95,22 @@ public sealed class AnyAsyncTests
 
 
 
-    [Fact]
-    public async Task AnyAsync_predicate_when_source_is_empty_returns_false()
+    [Theory]
+    [InlineData(new[] { 1, 2, 3, 4 }, true)]
+    [InlineData(new[] { 1, 2, 4, 5 }, false)]
+    [InlineData(new int[0], false)]
+    public async Task AnyAsync_predicate_match_cases_return_expected(int[] values, bool expected)
     {
-        var source = CreateSource();
+        if (values is null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        var source = TestSources.Create(values);
 
         var result = await source.AnyAsync(n => n % 3 == 0);
 
-        Assert.False(result);
-    }
-
-
-
-    [Fact]
-    public async Task AnyAsync_predicate_when_some_items_match_returns_true()
-    {
-        var source = CreateSource(1, 2, 3, 4);
-
-        var result = await source.AnyAsync(n => n % 3 == 0);
-
-        Assert.True(result);
-    }
-
-
-
-    [Fact]
-    public async Task AnyAsync_predicate_when_no_items_match_returns_false()
-    {
-        var source = CreateSource(1, 2, 4, 5);
-
-        var result = await source.AnyAsync(n => n % 3 == 0);
-
-        Assert.False(result);
+        Assert.Equal(expected, result);
     }
 
 
@@ -121,7 +119,7 @@ public sealed class AnyAsyncTests
     public async Task AnyAsync_predicate_short_circuits_on_first_match()
     {
         var enumerated = new List<int>();
-        var source = CreateTrackingSource(enumerated, 1, 2, 3, 4, 5);
+        var source = TestSources.CreateTracking(enumerated, 1, 2, 3, 4, 5);
 
         var result = await source.AnyAsync(n => n == 2);
 
@@ -134,7 +132,7 @@ public sealed class AnyAsyncTests
     [Fact]
     public async Task AnyAsync_predicate_when_predicate_throws_exception_propagates()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var sentinel = new InvalidOperationException("predicate boom");
 
         var actual = await Assert.ThrowsAsync<InvalidOperationException>
@@ -153,7 +151,7 @@ public sealed class AnyAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -167,7 +165,7 @@ public sealed class AnyAsyncTests
     public async Task AnyAsync_predicate_when_token_canceled_mid_iteration_throws_OperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -181,29 +179,6 @@ public sealed class AnyAsyncTests
                 tokenSource.Token
             ).AsTask()
         );
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateTrackingSource(List<int> tracker, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            tracker.Add(value);
-            yield return value;
-        }
     }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/CountAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/CountAsyncTests.cs
@@ -1,4 +1,4 @@
-namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+namespace Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit;
 
 public sealed class CountAsyncTests
 {
@@ -18,7 +18,7 @@ public sealed class CountAsyncTests
     [Fact]
     public async Task CountAsync_when_source_is_empty_returns_zero()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var result = await source.CountAsync();
 
@@ -28,9 +28,21 @@ public sealed class CountAsyncTests
 
 
     [Fact]
+    public async Task CountAsync_when_source_has_one_item_returns_one()
+    {
+        var source = TestSources.Create(42);
+
+        var result = await source.CountAsync();
+
+        Assert.Equal(1, result);
+    }
+
+
+
+    [Fact]
     public async Task CountAsync_when_source_has_items_returns_item_count()
     {
-        var source = CreateSource(1, 2, 3, 4);
+        var source = TestSources.Create(1, 2, 3, 4);
 
         var result = await source.CountAsync();
 
@@ -45,7 +57,7 @@ public sealed class CountAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -59,35 +71,12 @@ public sealed class CountAsyncTests
     public async Task CountAsync_when_token_canceled_mid_iteration_throws_OperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();
-        var source = CreateCancelingSource(tokenSource, 1, 2, 3);
+        var source = TestSources.CreateCanceling(tokenSource, 1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
             () => source.CountAsync(tokenSource.Token).AsTask()
         );
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateCancelingSource(CancellationTokenSource tokenSource, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-            tokenSource.Cancel();
-        }
     }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/DeepBehaviorTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/DeepBehaviorTests.cs
@@ -1,0 +1,141 @@
+// Deep-behavior tests for the Legacy terminal operators, modeled on the main
+// package's DeepBehaviorTests. Each test pins a contract the per-method test
+// files don't exercise directly: the token handed to GetAsyncEnumerator and
+// enumerator disposal on every exit path (exception, empty source, cancellation).
+
+namespace Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit;
+
+public sealed class DeepBehaviorTests
+{
+    [Fact]
+    public async Task CountAsync_passes_token_to_GetAsyncEnumerator()
+    {
+        using var cts = new CancellationTokenSource();
+        var fake = new InstrumentedAsyncEnumerable<int>(1, 2, 3);
+
+        var count = await fake.CountAsync(cts.Token);
+
+        Assert.Equal(3, count);
+        Assert.Equal(cts.Token, fake.CapturedToken);
+    }
+
+
+
+    [Fact]
+    public async Task ToListAsync_passes_token_to_GetAsyncEnumerator()
+    {
+        using var cts = new CancellationTokenSource();
+        var fake = new InstrumentedAsyncEnumerable<int>(1, 2, 3);
+
+        var list = await fake.ToListAsync(cts.Token);
+
+        Assert.Equal([1, 2, 3], list);
+        Assert.Equal(cts.Token, fake.CapturedToken);
+    }
+
+
+
+    [Fact]
+    public async Task AnyAsync_predicate_when_predicate_throws_disposes_enumerator()
+    {
+        var sentinel = new InvalidOperationException("predicate boom");
+        var fake = new InstrumentedAsyncEnumerable<int>(1, 2, 3);
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            () => fake.AnyAsync(_ => throw sentinel).AsTask()
+        );
+
+        Assert.Same(sentinel, actual);
+        Assert.True(fake.Disposed, "predicate exception must not skip enumerator disposal");
+    }
+
+
+
+    [Fact]
+    public async Task FirstAsync_when_source_is_empty_disposes_enumerator()
+    {
+        var fake = new InstrumentedAsyncEnumerable<int>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>
+        (
+            () => fake.FirstAsync().AsTask()
+        );
+
+        Assert.True(fake.Disposed, "empty-source InvalidOperationException must not skip enumerator disposal");
+    }
+
+
+
+    [Fact]
+    public async Task CountAsync_when_canceled_mid_iteration_disposes_enumerator()
+    {
+        // The first yielded item cancels the token; the post-increment
+        // ThrowIfCancellationRequested in the core loop throws, and the
+        // await-using must still dispose the enumerator.
+        using var cts = new CancellationTokenSource();
+        var fake = new InstrumentedAsyncEnumerable<int>(1, 2, 3)
+        {
+            OnItemYielded = () => cts.Cancel()
+        };
+
+        await Assert.ThrowsAsync<OperationCanceledException>
+        (
+            () => fake.CountAsync(cts.Token).AsTask()
+        );
+
+        Assert.True(fake.Disposed, "mid-iteration cancellation must dispose the source enumerator");
+    }
+
+
+
+    /// <summary>
+    /// IAsyncEnumerable fake that yields a fixed set of values while recording
+    /// the CancellationToken passed to <see cref="GetAsyncEnumerator"/> and
+    /// whether its enumerator was disposed. An optional
+    /// <see cref="OnItemYielded"/> callback runs after each item is produced,
+    /// letting tests cancel a token mid-iteration.
+    /// </summary>
+    private sealed class InstrumentedAsyncEnumerable<T>(params T[] values) : IAsyncEnumerable<T>
+    {
+        public CancellationToken CapturedToken { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public Action? OnItemYielded { get; set; }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            CapturedToken = cancellationToken;
+            return new Enumerator(this, values);
+        }
+
+        private sealed class Enumerator(InstrumentedAsyncEnumerable<T> owner, T[] values) : IAsyncEnumerator<T>
+        {
+            private int _index = -1;
+
+            public T Current { get; private set; } = default!;
+
+            public async ValueTask<bool> MoveNextAsync()
+            {
+                await Task.Yield();
+
+                _index++;
+                if (_index >= values.Length)
+                {
+                    return false;
+                }
+
+                Current = values[_index];
+                owner.OnItemYielded?.Invoke();
+                return true;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                owner.Disposed = true;
+                return default;
+            }
+        }
+    }
+}

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/FirstAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/FirstAsyncTests.cs
@@ -1,4 +1,4 @@
-namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+namespace Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit;
 
 public sealed class FirstAsyncTests
 {
@@ -18,7 +18,7 @@ public sealed class FirstAsyncTests
     [Fact]
     public async Task FirstAsync_when_source_is_empty_throws_InvalidOperationException()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         await Assert.ThrowsAsync<InvalidOperationException>
         (
@@ -31,7 +31,7 @@ public sealed class FirstAsyncTests
     [Fact]
     public async Task FirstAsync_when_source_has_items_returns_first_item()
     {
-        var source = CreateSource(5, 6, 7);
+        var source = TestSources.Create(5, 6, 7);
 
         var result = await source.FirstAsync();
 
@@ -44,7 +44,7 @@ public sealed class FirstAsyncTests
     public async Task FirstAsync_only_enumerates_first_item()
     {
         var enumerated = new List<int>();
-        var source = CreateTrackingSource(enumerated, 1, 2, 3);
+        var source = TestSources.CreateTracking(enumerated, 1, 2, 3);
 
         await source.FirstAsync();
 
@@ -59,35 +59,12 @@ public sealed class FirstAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
             () => source.FirstAsync(tokenSource.Token).AsTask()
         );
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateTrackingSource(List<int> tracker, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            tracker.Add(value);
-            yield return value;
-        }
     }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/FirstOrDefaultAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/FirstOrDefaultAsyncTests.cs
@@ -1,4 +1,4 @@
-namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+namespace Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit;
 
 public sealed class FirstOrDefaultAsyncTests
 {
@@ -18,7 +18,7 @@ public sealed class FirstOrDefaultAsyncTests
     [Fact]
     public async Task FirstOrDefaultAsync_when_source_is_empty_returns_default()
     {
-        var source = CreateSource<int>();
+        var source = TestSources.Create<int>();
 
         var result = await source.FirstOrDefaultAsync();
 
@@ -30,7 +30,19 @@ public sealed class FirstOrDefaultAsyncTests
     [Fact]
     public async Task FirstOrDefaultAsync_when_source_is_empty_reference_type_returns_null()
     {
-        var source = CreateSource<string>();
+        var source = TestSources.Create<string>();
+
+        var result = await source.FirstOrDefaultAsync();
+
+        Assert.Null(result);
+    }
+
+
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_when_source_is_empty_nullable_value_type_returns_null()
+    {
+        var source = TestSources.Create<int?>();
 
         var result = await source.FirstOrDefaultAsync();
 
@@ -42,7 +54,7 @@ public sealed class FirstOrDefaultAsyncTests
     [Fact]
     public async Task FirstOrDefaultAsync_when_source_has_items_returns_first_item()
     {
-        var source = CreateSource(5, 6, 7);
+        var source = TestSources.Create(5, 6, 7);
 
         var result = await source.FirstOrDefaultAsync();
 
@@ -55,7 +67,7 @@ public sealed class FirstOrDefaultAsyncTests
     public async Task FirstOrDefaultAsync_only_enumerates_first_item()
     {
         var enumerated = new List<int>();
-        var source = CreateTrackingSource(enumerated, 1, 2, 3);
+        var source = TestSources.CreateTracking(enumerated, 1, 2, 3);
 
         await source.FirstOrDefaultAsync();
 
@@ -70,35 +82,12 @@ public sealed class FirstOrDefaultAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
             () => source.FirstOrDefaultAsync(tokenSource.Token).AsTask()
         );
-    }
-
-
-
-    private static async IAsyncEnumerable<T> CreateSource<T>(params T[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateTrackingSource(List<int> tracker, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            tracker.Add(value);
-            yield return value;
-        }
     }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/TestSources.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/TestSources.cs
@@ -1,0 +1,51 @@
+namespace Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit;
+
+/// <summary>
+/// Shared async-sequence generators used across the per-method test files.
+/// </summary>
+internal static class TestSources
+{
+    /// <summary>
+    /// Yields <paramref name="values"/> in order, with an await between items.
+    /// </summary>
+    public static async IAsyncEnumerable<T> Create<T>(params T[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            yield return value;
+        }
+    }
+
+
+
+    /// <summary>
+    /// Yields <paramref name="values"/> in order, recording each item in
+    /// <paramref name="tracker"/> immediately before it is yielded.
+    /// </summary>
+    public static async IAsyncEnumerable<int> CreateTracking(List<int> tracker, params int[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            tracker.Add(value);
+            yield return value;
+        }
+    }
+
+
+
+    /// <summary>
+    /// Yields <paramref name="values"/> in order, canceling
+    /// <paramref name="tokenSource"/> after each item is yielded.
+    /// </summary>
+    public static async IAsyncEnumerable<int> CreateCanceling(CancellationTokenSource tokenSource, params int[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            yield return value;
+            tokenSource.Cancel();
+        }
+    }
+}

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/ToListAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/ToListAsyncTests.cs
@@ -1,4 +1,4 @@
-namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+namespace Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit;
 
 public sealed class ToListAsyncTests
 {
@@ -18,7 +18,7 @@ public sealed class ToListAsyncTests
     [Fact]
     public async Task ToListAsync_when_source_is_empty_returns_empty_list()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var result = await source.ToListAsync();
 
@@ -28,13 +28,38 @@ public sealed class ToListAsyncTests
 
 
     [Fact]
+    public async Task ToListAsync_when_source_has_one_item_returns_single_item_list()
+    {
+        var source = TestSources.Create(42);
+
+        var result = await source.ToListAsync();
+
+        Assert.Equal([42], result);
+    }
+
+
+
+    [Fact]
     public async Task ToListAsync_when_source_has_items_returns_items_in_order()
     {
-        var source = CreateSource(1, 2, 3, 4);
+        var source = TestSources.Create(1, 2, 3, 4);
 
         var result = await source.ToListAsync();
 
         Assert.Equal([1, 2, 3, 4], result);
+    }
+
+
+
+    [Fact]
+    public async Task ToListAsync_returns_independent_list_per_call()
+    {
+        var list1 = await TestSources.Create(1, 2, 3).ToListAsync();
+        var list2 = await TestSources.Create(1, 2, 3).ToListAsync();
+
+        Assert.NotSame(list1, list2);
+        Assert.Equal([1, 2, 3], list1);
+        Assert.Equal([1, 2, 3], list2);
     }
 
 
@@ -45,7 +70,7 @@ public sealed class ToListAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -59,35 +84,12 @@ public sealed class ToListAsyncTests
     public async Task ToListAsync_when_token_canceled_mid_iteration_throws_OperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();
-        var source = CreateCancelingSource(tokenSource, 1, 2, 3);
+        var source = TestSources.CreateCanceling(tokenSource, 1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
             () => source.ToListAsync(tokenSource.Token).AsTask()
         );
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateCancelingSource(CancellationTokenSource tokenSource, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-            tokenSource.Cancel();
-        }
     }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit/Wolfgang.Extensions.IAsyncEnumerable.Legacy.Tests.Unit.csproj
@@ -6,7 +6,6 @@
 	     so it resolves via NuGet fallback to the netstandard2.0 build — between
 	     the two, both compiled surfaces of the package are exercised. -->
 	<TargetFrameworks>net462;net10.0</TargetFrameworks>
-	<Version>0.5.4</Version>
 	<LangVersion>latest</LangVersion>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>
@@ -68,6 +67,7 @@
 
 	<ItemGroup>
 		<Using Include="Xunit" />
+		<Using Include="Wolfgang.Extensions.IAsyncEnumerable" />
 	</ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Concurrency/ConcurrencyStressTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Concurrency/ConcurrencyStressTests.cs
@@ -1,9 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Wolfgang.Extensions.IAsyncEnumerable;
-
 namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Concurrency;
 
 /// <summary>

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.DocExamples/DocExampleSource.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.DocExamples/DocExampleSource.cs
@@ -70,27 +70,36 @@ public sealed class DocExample : IXunitSerializable
 
 
 /// <summary>
-/// Locates the library's source directory and extracts every XML-doc
+/// Locates the repository's src packages and extracts every XML-doc
 /// &lt;example&gt;&lt;code&gt; block for compilation.
 /// </summary>
 public static class DocExampleSource
 {
     private const string LibraryDirectoryName = "Wolfgang.Extensions.IAsyncEnumerable";
 
+    private const string LegacyLibraryDirectoryName = "Wolfgang.Extensions.IAsyncEnumerable.Legacy";
+
 
 
     /// <summary>
-    /// Extracts every &lt;example&gt;&lt;code&gt; block from every .cs file under the
-    /// library's src directory.
+    /// Extracts every &lt;example&gt;&lt;code&gt; block from every .cs file under
+    /// both packages' src directories (the main library and the Legacy
+    /// terminal-operator package).
     /// </summary>
     public static IReadOnlyList<DocExample> ExtractAll()
     {
-        var srcDir = FindSrcDirectory();
+        // The main package directory is the walk-up anchor; the Legacy package
+        // sits next to it under the same src/ root.
+        var mainDir = FindSrcDirectory();
+        var srcRoot = Path.GetDirectoryName(mainDir)!;
         var examples = new List<DocExample>();
 
-        foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs", SearchOption.TopDirectoryOnly))
+        foreach (var packageDir in new[] { mainDir, Path.Combine(srcRoot, LegacyLibraryDirectoryName) })
         {
-            examples.AddRange(ExtractFromFile(file));
+            foreach (var file in Directory.EnumerateFiles(packageDir, "*.cs", SearchOption.TopDirectoryOnly))
+            {
+                examples.AddRange(ExtractFromFile(file));
+            }
         }
 
         return examples;

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ChunkAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ChunkAsyncTests.cs
@@ -3,9 +3,9 @@ namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
 public sealed class ChunkAsyncTests
 {
     [Fact]
-    public async Task ChunkAsync_WithExactMultipleChunkSize_ReturnsExpectedChunks()
+    public async Task ChunkAsync_when_chunk_size_is_exact_multiple_returns_expected_chunks()
     {
-        var source = CreateSource(1, 2, 3, 4);
+        var source = TestSources.Create(1, 2, 3, 4);
 
         var chunks = await CollectChunksAsync(source.ChunkAsync(2));
 
@@ -15,9 +15,9 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_WithRemainderChunk_ReturnsFinalPartialChunk()
+    public async Task ChunkAsync_when_source_has_remainder_returns_final_partial_chunk()
     {
-        var source = CreateSource(1, 2, 3, 4, 5);
+        var source = TestSources.Create(1, 2, 3, 4, 5);
 
         var chunks = await CollectChunksAsync(source.ChunkAsync(2));
 
@@ -28,9 +28,9 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_WithChunkSizeLargerThanSource_YieldsSingleChunk()
+    public async Task ChunkAsync_when_chunk_size_larger_than_source_yields_single_chunk()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         var chunks = await CollectChunksAsync(source.ChunkAsync(10));
 
@@ -39,9 +39,9 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_WithChunkSizeOfOne_EmitsSingletonChunks()
+    public async Task ChunkAsync_when_chunk_size_is_one_emits_singleton_chunks()
     {
-        var source = CreateSource(4, 5, 6);
+        var source = TestSources.Create(4, 5, 6);
 
         var chunks = await CollectChunksAsync(source.ChunkAsync(1));
 
@@ -52,9 +52,9 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_WithEmptySource_YieldsNoChunks()
+    public async Task ChunkAsync_when_source_is_empty_yields_no_chunks()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var chunks = await CollectChunksAsync(source.ChunkAsync(4));
 
@@ -62,7 +62,7 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public void ChunkAsync_WithNullSource_ThrowsArgumentNullException()
+    public void ChunkAsync_when_source_is_null_throws_ArgumentNullException()
     {
         IAsyncEnumerable<int> source = null!;
 
@@ -70,9 +70,9 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_YieldsDistinctChunkInstances()
+    public async Task ChunkAsync_yields_distinct_chunk_instances()
     {
-        var source = CreateSource(1, 2, 3, 4);
+        var source = TestSources.Create(1, 2, 3, 4);
 
         var chunks = await CollectChunksAsync(source.ChunkAsync(2));
 
@@ -82,9 +82,9 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_WithDelayedSource_PreservesOrdering()
+    public async Task ChunkAsync_with_delayed_source_preserves_ordering()
     {
-        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4, 5);
+        var source = TestSources.CreateDelayed(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4, 5);
 
         var chunks = await CollectChunksAsync(source.ChunkAsync(3));
 
@@ -94,7 +94,7 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_DoesNotEnumerateSourceUntilConsumed()
+    public async Task ChunkAsync_does_not_enumerate_source_until_consumed()
     {
         var source = new TrackingAsyncEnumerable(1, 2, 3, 4);
 
@@ -108,12 +108,12 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_WithPreCanceledToken_ThrowsOperationCanceledException()
+    public async Task ChunkAsync_with_pre_canceled_token_throws_OperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -122,7 +122,7 @@ public sealed class ChunkAsyncTests
     }
 
     [Fact]
-    public async Task ChunkAsync_WithPreCanceledToken_NeverEnumeratesSource()
+    public async Task ChunkAsync_with_pre_canceled_token_never_enumerates_source()
     {
         // The pre-loop ThrowIfCancellationRequested() must fire before the source is
         // ever touched. A source with enough items to fill a full chunk would otherwise
@@ -146,11 +146,11 @@ public sealed class ChunkAsyncTests
 
 
     [Fact]
-    public async Task ChunkAsync_WhenCancellationRequestedDuringEnumeration_ThrowsOperationCanceledException()
+    public async Task ChunkAsync_when_cancellation_requested_during_enumeration_throws_OperationCanceledException()
     {
         using var tokenSource = new CancellationTokenSource();
 
-        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
+        var source = TestSources.CreateDelayed(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
 
         var chunked = source.ChunkAsync(2, tokenSource.Token);
 
@@ -170,29 +170,11 @@ public sealed class ChunkAsyncTests
     [InlineData(0)]
     [InlineData(-1)]
     [InlineData(-5)]
-    public async Task ChunkAsync_WithNonPositiveChunkSize_ThrowsArgumentOutOfRangeException(int chunkSize)
+    public async Task ChunkAsync_when_chunk_size_is_not_positive_throws_ArgumentOutOfRangeException(int chunkSize)
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => CollectChunksAsync(source.ChunkAsync(chunkSize)));
-    }
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-    private static async IAsyncEnumerable<int> CreateDelayedSource(TimeSpan delay, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Delay(delay);
-            yield return value;
-        }
     }
 
     private static async Task<List<ICollection<int>>> CollectChunksAsync(IAsyncEnumerable<ICollection<int>> chunks)
@@ -204,16 +186,5 @@ public sealed class ChunkAsyncTests
         }
 
         return result;
-    }
-
-    private sealed class TrackingAsyncEnumerable(params int[] values) : IAsyncEnumerable<int>
-    {
-        public bool EnumerationStarted { get; private set; }
-
-        public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            EnumerationStarted = true;
-            return CreateSource(values).GetAsyncEnumerator(cancellationToken);
-        }
     }
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/CultureInvarianceTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/CultureInvarianceTests.cs
@@ -41,7 +41,7 @@ public sealed class CultureInvarianceTests
         await RunUnderCultureAsync(culture, async () =>
         {
             var chunks = new List<int[]>();
-            await foreach (var chunk in CreateSource(1, 37).ChunkAsync(10))
+            await foreach (var chunk in CreateRange(1, 37).ChunkAsync(10))
             {
                 chunks.Add([.. chunk]);
             }
@@ -61,7 +61,7 @@ public sealed class CultureInvarianceTests
         {
             var seen = new List<int>();
             var yielded = new List<int>();
-            await foreach (var item in CreateSource(1, 5).DoAsync(x => seen.Add(x)))
+            await foreach (var item in CreateRange(1, 5).DoAsync(x => seen.Add(x)))
             {
                 yielded.Add(item);
             }
@@ -80,7 +80,7 @@ public sealed class CultureInvarianceTests
         await RunUnderCultureAsync(culture, async () =>
         {
             var sum = 0;
-            await CreateSource(1, 5).ForEachAsync(x => sum += x);
+            await CreateRange(1, 5).ForEachAsync(x => sum += x);
             Assert.Equal(15, sum);
         });
     }
@@ -93,8 +93,8 @@ public sealed class CultureInvarianceTests
     {
         await RunUnderCultureAsync(culture, async () =>
         {
-            Assert.True(await CreateSource().IsEmptyAsync());
-            Assert.False(await CreateSource(1).IsEmptyAsync());
+            Assert.True(await TestSources.Create<int>().IsEmptyAsync());
+            Assert.False(await TestSources.Create(1).IsEmptyAsync());
         });
     }
 
@@ -106,8 +106,8 @@ public sealed class CultureInvarianceTests
     {
         await RunUnderCultureAsync(culture, async () =>
         {
-            Assert.True(await CreateSource(1, 2, 3).NoneAsync(x => x > 100));
-            Assert.False(await CreateSource(1, 2, 3).NoneAsync(x => x == 2));
+            Assert.True(await TestSources.Create(1, 2, 3).NoneAsync(x => x > 100));
+            Assert.False(await TestSources.Create(1, 2, 3).NoneAsync(x => x == 2));
         });
     }
 
@@ -134,18 +134,7 @@ public sealed class CultureInvarianceTests
 
 
 
-    private static async IAsyncEnumerable<int> CreateSource(params int[] items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-            yield return item;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateSource(int start, int end)
+    private static async IAsyncEnumerable<int> CreateRange(int start, int end)
     {
         for (var i = start; i <= end; i++)
         {

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DeepBehaviorTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DeepBehaviorTests.cs
@@ -103,7 +103,7 @@ public sealed class DeepBehaviorTests
     {
         AmbientId.Value = 42;
         var observed = new List<int>();
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await foreach (var _ in source.DoAsync(_ => observed.Add(AmbientId.Value)))
         {
@@ -119,7 +119,7 @@ public sealed class DeepBehaviorTests
     {
         AmbientId.Value = 17;
         var observed = new List<int>();
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await source.ForEachAsync(_ => observed.Add(AmbientId.Value));
 
@@ -137,7 +137,7 @@ public sealed class DeepBehaviorTests
         AmbientId.Value = 99;
         var observedBefore = new List<int>();
         var observedAfter = new List<int>();
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await foreach (var _ in source.DoAsync(async _ =>
         {
@@ -162,7 +162,7 @@ public sealed class DeepBehaviorTests
         // last-write-wins. The async overload, by contrast, captures the
         // execution context per await and the inner mutation does NOT leak.
         AmbientId.Value = 1;
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await foreach (var _ in source.DoAsync(async _ =>
         {
@@ -280,17 +280,6 @@ public sealed class DeepBehaviorTests
     // ----------------------------------------------------------------------
     // Helpers
     // ----------------------------------------------------------------------
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
 
     private static async IAsyncEnumerable<int> CreateSourceFrom(IReadOnlyList<int> values)
     {

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DoAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/DoAsyncTests.cs
@@ -5,7 +5,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_when_source_has_items_executes_action_on_each()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var observed = new List<int>();
 
         var result = await CollectAsync(source.DoAsync(x => observed.Add(x)));
@@ -19,7 +19,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_when_source_is_empty_executes_no_actions()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
         var observed = new List<int>();
 
         var result = await CollectAsync(source.DoAsync(x => observed.Add(x)));
@@ -46,7 +46,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_when_action_is_null_throws_ArgumentNullException()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<ArgumentNullException>
         (
@@ -59,7 +59,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_yields_original_items_unchanged()
     {
-        var source = CreateSource(10, 20, 30);
+        var source = TestSources.Create(10, 20, 30);
 
         var result = await CollectAsync(source.DoAsync(_ => { }));
 
@@ -71,7 +71,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_preserves_ordering()
     {
-        var source = CreateSource(5, 3, 1, 4, 2);
+        var source = TestSources.Create(5, 3, 1, 4, 2);
         var observed = new List<int>();
 
         var result = await CollectAsync(source.DoAsync(x => observed.Add(x)));
@@ -104,7 +104,7 @@ public sealed class DoAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -143,7 +143,7 @@ public sealed class DoAsyncTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
+        var source = TestSources.CreateDelayed(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
 
         var tapped = source.DoAsync(_ => { }, tokenSource.Token);
 
@@ -164,18 +164,21 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_when_action_throws_propagates_exception()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
+        var sentinel = new InvalidOperationException("test");
 
-        await Assert.ThrowsAsync<InvalidOperationException>
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>
         (
             () => CollectAsync(source.DoAsync(x =>
             {
                 if (x == 2)
                 {
-                    throw new InvalidOperationException("test");
+                    throw sentinel;
                 }
             }))
         );
+
+        Assert.Same(sentinel, actual);
     }
 
 
@@ -183,7 +186,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_executes_action_before_yielding_item()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var log = new List<string>();
 
         await foreach (var item in source.DoAsync(x => log.Add($"action:{x}")))
@@ -203,7 +206,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_when_source_has_items_executes_async_action_on_each()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var observed = new List<int>();
 
         var result = await CollectAsync(source.DoAsync(async x =>
@@ -221,7 +224,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_when_source_is_empty_executes_no_actions()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
         var observed = new List<int>();
 
         var result = await CollectAsync(source.DoAsync(async x =>
@@ -252,7 +255,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_when_action_is_null_throws_ArgumentNullException()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<ArgumentNullException>
         (
@@ -265,7 +268,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_yields_original_items_unchanged()
     {
-        var source = CreateSource(10, 20, 30);
+        var source = TestSources.Create(10, 20, 30);
 
         var result = await CollectAsync(source.DoAsync(_ => Task.CompletedTask));
 
@@ -277,7 +280,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_preserves_ordering()
     {
-        var source = CreateSource(5, 3, 1, 4, 2);
+        var source = TestSources.Create(5, 3, 1, 4, 2);
         var observed = new List<int>();
 
         var result = await CollectAsync(source.DoAsync(x =>
@@ -314,7 +317,7 @@ public sealed class DoAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -352,7 +355,7 @@ public sealed class DoAsyncTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
+        var source = TestSources.CreateDelayed(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
 
         var tapped = source.DoAsync(_ => Task.CompletedTask, tokenSource.Token);
 
@@ -373,20 +376,23 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_when_action_throws_propagates_exception()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
+        var sentinel = new InvalidOperationException("test");
 
-        await Assert.ThrowsAsync<InvalidOperationException>
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>
         (
             () => CollectAsync(source.DoAsync(x =>
             {
                 if (x == 2)
                 {
-                    throw new InvalidOperationException("test");
+                    throw sentinel;
                 }
 
                 return Task.CompletedTask;
             }))
         );
+
+        Assert.Same(sentinel, actual);
     }
 
 
@@ -394,7 +400,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_executes_action_before_yielding_item()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var log = new List<string>();
 
         await foreach (var item in source.DoAsync(x =>
@@ -418,7 +424,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Action_can_chain_with_ChunkAsync()
     {
-        var source = CreateSource(1, 2, 3, 4, 5, 6);
+        var source = TestSources.Create(1, 2, 3, 4, 5, 6);
         var observed = new List<int>();
 
         var chunks = new List<ICollection<int>>();
@@ -438,7 +444,7 @@ public sealed class DoAsyncTests
     [Fact]
     public async Task DoAsync_Func_can_chain_with_ChunkAsync()
     {
-        var source = CreateSource(1, 2, 3, 4, 5, 6);
+        var source = TestSources.Create(1, 2, 3, 4, 5, 6);
         var observed = new List<int>();
 
         var chunks = new List<ICollection<int>>();
@@ -459,24 +465,6 @@ public sealed class DoAsyncTests
 
 
 
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-    private static async IAsyncEnumerable<int> CreateDelayedSource(TimeSpan delay, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Delay(delay);
-            yield return value;
-        }
-    }
-
     private static async Task<List<int>> CollectAsync(IAsyncEnumerable<int> source)
     {
         var result = new List<int>();
@@ -486,16 +474,5 @@ public sealed class DoAsyncTests
         }
 
         return result;
-    }
-
-    private sealed class TrackingAsyncEnumerable(params int[] values) : IAsyncEnumerable<int>
-    {
-        public bool EnumerationStarted { get; private set; }
-
-        public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            EnumerationStarted = true;
-            return CreateSource(values).GetAsyncEnumerator(cancellationToken);
-        }
     }
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ForEachAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/ForEachAsyncTests.cs
@@ -5,7 +5,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Action_when_source_has_items_executes_action_on_each()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var observed = new List<int>();
 
         await source.ForEachAsync(x => observed.Add(x));
@@ -18,7 +18,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Action_when_source_is_empty_executes_no_actions()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
         var observed = new List<int>();
 
         await source.ForEachAsync(x => observed.Add(x));
@@ -44,7 +44,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Action_when_action_is_null_throws_ArgumentNullException()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<ArgumentNullException>
         (
@@ -57,7 +57,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Action_preserves_ordering()
     {
-        var source = CreateSource(5, 3, 1, 4, 2);
+        var source = TestSources.Create(5, 3, 1, 4, 2);
         var observed = new List<int>();
 
         await source.ForEachAsync(x => observed.Add(x));
@@ -73,7 +73,7 @@ public sealed class ForEachAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -93,7 +93,7 @@ public sealed class ForEachAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var invoked = false;
 
         await Assert.ThrowsAsync<OperationCanceledException>
@@ -111,7 +111,7 @@ public sealed class ForEachAsyncTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
+        var source = TestSources.CreateDelayed(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
         var observed = new List<int>();
 
         await Assert.ThrowsAsync<OperationCanceledException>
@@ -132,6 +132,10 @@ public sealed class ForEachAsyncTests
                 );
             }
         );
+
+        // The action cancels on the first item, and the post-action token check
+        // throws before a second item is ever requested — so exactly [1] is observed.
+        Assert.Equal([1], observed);
     }
 
 
@@ -139,18 +143,21 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Action_when_action_throws_propagates_exception()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
+        var sentinel = new InvalidOperationException("test");
 
-        await Assert.ThrowsAsync<InvalidOperationException>
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>
         (
             () => source.ForEachAsync(x =>
             {
                 if (x == 2)
                 {
-                    throw new InvalidOperationException("test");
+                    throw sentinel;
                 }
             })
         );
+
+        Assert.Same(sentinel, actual);
     }
 
 
@@ -158,7 +165,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Func_when_source_has_items_executes_async_action_on_each()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var observed = new List<int>();
 
         await source.ForEachAsync(async x =>
@@ -175,7 +182,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Func_when_source_is_empty_executes_no_actions()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
         var observed = new List<int>();
 
         await source.ForEachAsync(async x =>
@@ -205,7 +212,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Func_when_action_is_null_throws_ArgumentNullException()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<ArgumentNullException>
         (
@@ -218,7 +225,7 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Func_preserves_ordering()
     {
-        var source = CreateSource(5, 3, 1, 4, 2);
+        var source = TestSources.Create(5, 3, 1, 4, 2);
         var observed = new List<int>();
 
         await source.ForEachAsync(x =>
@@ -238,7 +245,7 @@ public sealed class ForEachAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -256,7 +263,7 @@ public sealed class ForEachAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var invoked = false;
 
         await Assert.ThrowsAsync<OperationCanceledException>
@@ -278,7 +285,7 @@ public sealed class ForEachAsyncTests
     {
         using var tokenSource = new CancellationTokenSource();
 
-        var source = CreateDelayedSource(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
+        var source = TestSources.CreateDelayed(TimeSpan.FromMilliseconds(10), 1, 2, 3, 4);
         var observed = new List<int>();
 
         await Assert.ThrowsAsync<OperationCanceledException>
@@ -301,6 +308,10 @@ public sealed class ForEachAsyncTests
                 );
             }
         );
+
+        // The action cancels on the first item, and the post-action token check
+        // throws before a second item is ever requested — so exactly [1] is observed.
+        Assert.Equal([1], observed);
     }
 
 
@@ -308,42 +319,25 @@ public sealed class ForEachAsyncTests
     [Fact]
     public async Task ForEachAsync_Func_when_action_throws_propagates_exception()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
+        var sentinel = new InvalidOperationException("test");
 
-        await Assert.ThrowsAsync<InvalidOperationException>
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>
         (
             () => source.ForEachAsync(x =>
             {
                 if (x == 2)
                 {
-                    throw new InvalidOperationException("test");
+                    throw sentinel;
                 }
 
                 return Task.CompletedTask;
             })
         );
+
+        Assert.Same(sentinel, actual);
     }
 
 
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateDelayedSource(TimeSpan delay, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Delay(delay);
-            yield return value;
-        }
-    }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/IsEmptyAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/IsEmptyAsyncTests.cs
@@ -18,7 +18,7 @@ public sealed class IsEmptyAsyncTests
     [Fact]
     public async Task IsEmptyAsync_when_source_is_empty_returns_true()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var result = await source.IsEmptyAsync();
 
@@ -30,7 +30,7 @@ public sealed class IsEmptyAsyncTests
     [Fact]
     public async Task IsEmptyAsync_when_source_has_items_returns_false()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         var result = await source.IsEmptyAsync();
 
@@ -42,7 +42,7 @@ public sealed class IsEmptyAsyncTests
     [Fact]
     public async Task IsEmptyAsync_when_source_has_single_item_returns_false()
     {
-        var source = CreateSource(42);
+        var source = TestSources.Create(42);
 
         var result = await source.IsEmptyAsync();
 
@@ -57,7 +57,7 @@ public sealed class IsEmptyAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -66,14 +66,5 @@ public sealed class IsEmptyAsyncTests
     }
 
 
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/IsNullOrEmptyAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/IsNullOrEmptyAsyncTests.cs
@@ -17,7 +17,7 @@ public sealed class IsNullOrEmptyAsyncTests
     [Fact]
     public async Task IsNullOrEmptyAsync_when_source_is_empty_returns_true()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var result = await source.IsNullOrEmptyAsync();
 
@@ -29,7 +29,7 @@ public sealed class IsNullOrEmptyAsyncTests
     [Fact]
     public async Task IsNullOrEmptyAsync_when_source_has_items_returns_false()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         var result = await source.IsNullOrEmptyAsync();
 
@@ -41,7 +41,7 @@ public sealed class IsNullOrEmptyAsyncTests
     [Fact]
     public async Task IsNullOrEmptyAsync_when_source_has_single_item_returns_false()
     {
-        var source = CreateSource(42);
+        var source = TestSources.Create(42);
 
         var result = await source.IsNullOrEmptyAsync();
 
@@ -56,7 +56,7 @@ public sealed class IsNullOrEmptyAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -82,14 +82,5 @@ public sealed class IsNullOrEmptyAsyncTests
     }
 
 
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/NoneAsyncTests.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/NoneAsyncTests.cs
@@ -18,7 +18,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_when_source_is_empty_returns_true()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var result = await source.NoneAsync();
 
@@ -30,7 +30,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_when_source_has_items_returns_false()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         var result = await source.NoneAsync();
 
@@ -45,7 +45,7 @@ public sealed class NoneAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -71,7 +71,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_predicate_when_predicate_is_null_throws_ArgumentNullException()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<ArgumentNullException>
         (
@@ -84,7 +84,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_predicate_when_all_items_match_returns_false()
     {
-        var source = CreateSource(3, 6, 9, 12);
+        var source = TestSources.Create(3, 6, 9, 12);
 
         var result = await source.NoneAsync(n => n % 3 == 0);
 
@@ -96,7 +96,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_predicate_when_some_items_match_returns_false()
     {
-        var source = CreateSource(1, 2, 3, 4);
+        var source = TestSources.Create(1, 2, 3, 4);
 
         var result = await source.NoneAsync(n => n % 3 == 0);
 
@@ -108,7 +108,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_predicate_when_no_items_match_returns_true()
     {
-        var source = CreateSource(1, 2, 4, 5);
+        var source = TestSources.Create(1, 2, 4, 5);
 
         var result = await source.NoneAsync(n => n % 3 == 0);
 
@@ -120,7 +120,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_predicate_when_source_is_empty_returns_true()
     {
-        var source = CreateSource();
+        var source = TestSources.Create<int>();
 
         var result = await source.NoneAsync(n => n % 3 == 0);
 
@@ -135,7 +135,7 @@ public sealed class NoneAsyncTests
         using var tokenSource = new CancellationTokenSource();
         tokenSource.Cancel();
 
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -149,7 +149,7 @@ public sealed class NoneAsyncTests
     public async Task NoneAsync_predicate_short_circuits_on_first_match()
     {
         var enumerated = new List<int>();
-        var source = CreateTrackingSource(enumerated, 1, 2, 3, 4, 5);
+        var source = TestSources.CreateTracking(enumerated, 1, 2, 3, 4, 5);
 
         var result = await source.NoneAsync(n => n == 2);
 
@@ -162,7 +162,7 @@ public sealed class NoneAsyncTests
     [Fact]
     public async Task NoneAsync_predicate_when_predicate_throws_exception_propagates()
     {
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
         var sentinel = new InvalidOperationException("predicate boom");
 
         var actual = await Assert.ThrowsAsync<InvalidOperationException>
@@ -179,11 +179,10 @@ public sealed class NoneAsyncTests
     public async Task NoneAsync_predicate_when_token_canceled_mid_iteration_throws_OperationCanceledException()
     {
         // Token starts uncanceled, so the upfront ThrowIfCancellationRequested passes.
-        // The first predicate invocation cancels the token; the post-predicate
-        // ThrowIfCancellationRequested (NoneAsync predicate-overload, source line 467)
-        // is what we're exercising.
+        // The first predicate invocation cancels the token; the post-predicate token
+        // check in the NoneAsync predicate overload is what we're exercising.
         using var tokenSource = new CancellationTokenSource();
-        var source = CreateSource(1, 2, 3);
+        var source = TestSources.Create(1, 2, 3);
 
         await Assert.ThrowsAsync<OperationCanceledException>
         (
@@ -200,26 +199,5 @@ public sealed class NoneAsyncTests
     }
 
 
-
-    private static async IAsyncEnumerable<int> CreateSource(params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            yield return value;
-        }
-    }
-
-
-
-    private static async IAsyncEnumerable<int> CreateTrackingSource(List<int> tracker, params int[] values)
-    {
-        foreach (var value in values)
-        {
-            await Task.Yield();
-            tracker.Add(value);
-            yield return value;
-        }
-    }
 
 }

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/TestSources.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/TestSources.cs
@@ -1,0 +1,50 @@
+namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+
+/// <summary>
+/// Shared async-sequence generators used across the per-method test files.
+/// </summary>
+internal static class TestSources
+{
+    /// <summary>
+    /// Yields <paramref name="values"/> in order, with an await between items.
+    /// </summary>
+    public static async IAsyncEnumerable<T> Create<T>(params T[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            yield return value;
+        }
+    }
+
+
+
+    /// <summary>
+    /// Yields <paramref name="values"/> in order, recording each item in
+    /// <paramref name="tracker"/> immediately before it is yielded.
+    /// </summary>
+    public static async IAsyncEnumerable<int> CreateTracking(List<int> tracker, params int[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Yield();
+            tracker.Add(value);
+            yield return value;
+        }
+    }
+
+
+
+    /// <summary>
+    /// Yields <paramref name="values"/> in order, awaiting
+    /// <paramref name="delay"/> before each item.
+    /// </summary>
+    public static async IAsyncEnumerable<int> CreateDelayed(TimeSpan delay, params int[] values)
+    {
+        foreach (var value in values)
+        {
+            await Task.Delay(delay);
+            yield return value;
+        }
+    }
+}

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/TrackingAsyncEnumerable.cs
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/TrackingAsyncEnumerable.cs
@@ -1,0 +1,19 @@
+namespace Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit;
+
+/// <summary>
+/// IAsyncEnumerable fake that records whether enumeration has started, used to
+/// verify deferred-execution contracts (the source must not be touched until
+/// the composed sequence is actually consumed).
+/// </summary>
+internal sealed class TrackingAsyncEnumerable(params int[] values) : IAsyncEnumerable<int>
+{
+    public bool EnumerationStarted { get; private set; }
+
+
+
+    public IAsyncEnumerator<int> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        EnumerationStarted = true;
+        return TestSources.Create(values).GetAsyncEnumerator(cancellationToken);
+    }
+}

--- a/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 	<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-	<Version>0.5.0</Version>
 	<LangVersion>latest</LangVersion>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>


### PR DESCRIPTION
Part 2 of 4 of the code-review fix stack (stacks on the src-fixes PR).

## Fixes
**Legacy suite deepened (34 → 44 cases)**
- New `DeepBehaviorTests` + `InstrumentedAsyncEnumerable` fake: pins the token actually reaches `GetAsyncEnumerator` (CountAsync/ToListAsync) and the enumerator is **disposed** on predicate-throw, empty-`FirstAsync`, and mid-iteration-cancel paths — previously unverified
- `AnyAsync` only-enumerates-first-item test; predicate-match trio collapsed to a Theory; single-element boundary cases (Count/ToList); `int?` empty-source case (FirstOrDefault); independent-list pin (ToList)
- Namespace corrected to `...Legacy.Tests.Unit` (was squatting on the main project's)

**Main suite**
- `ChunkAsyncTests` renamed to house snake_case (only file out of step)
- Sentinel-identity asserts (`Assert.Same`) on DoAsync/ForEachAsync throw tests; ForEachAsync cancel tests now assert the `observed` list (was write-only)
- CultureInvariance overload footgun killed (`CreateRange` rename); stale line-number comment dropped

**Dedup / dead code**
- `TestSources.cs` in both Unit projects — the generator bodies were duplicated **13×**; `TrackingAsyncEnumerable` deduped into its own file
- `DocExampleSource` scans **both** src packages (future Legacy `<example>` blocks now covered by the doc-rot gate)
- Deleted: commented-out `ChunkAsyncV2` benchmark, redundant usings, unused example variable, meaningless `<Version>` on non-packable test csprojs

## Test plan
- [x] Solution Release build 0 errors
- [x] Main Unit 135/135 (net10.0 + net462) · Legacy 44/44 (both TFMs) · DocExamples 12/12 · Concurrency 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)