### PR TITLE
Code-review fixes: docs accuracy, docfx pipeline, solution file, Legacy example

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,9 +5,9 @@
 This is a .NET library project that provides extension methods for `IAsyncEnumerable<T>`. The library is designed to make working with async sequences easier and more efficient, with features like chunking, batching, and other utility methods.
 
 **Repository Type**: .NET Library Project  
-**Target Frameworks**: .NET Framework 4.6.2, .NET Standard 2.0, .NET 8.0, .NET 10.0  
+**Target Frameworks**: .NET Framework 4.6.2, .NET Standard 2.0, .NET 8.0, .NET 10.0 (main package); .NET Framework 4.6.2, .NET Standard 2.0 only (Legacy package)  
 **Primary Language**: C#  
-**Package Name**: Wolfgang.Extensions.IAsyncEnumerable  
+**Packages**: Wolfgang.Extensions.IAsyncEnumerable (main) and Wolfgang.Extensions.IAsyncEnumerable.Legacy (terminal operators for TFMs without System.Linq.AsyncEnumerable), both under `src/`  
 
 ## Build and Validation Instructions
 
@@ -65,9 +65,12 @@ This is a .NET library project that provides extension methods for `IAsyncEnumer
 root/
 ├── IAsyncEnumerable Extensions.slnx    # Solution file
 ├── src/                                # Library projects
-│   └── Wolfgang.Extensions.IAsyncEnumerable/
-│       ├── Wolfgang.Extensions.IAsyncEnumerable.csproj
-│       └── IAsyncEnumerableExtensions.cs
+│   ├── Wolfgang.Extensions.IAsyncEnumerable/
+│   │   ├── Wolfgang.Extensions.IAsyncEnumerable.csproj
+│   │   └── IAsyncEnumerableExtensions.cs
+│   └── Wolfgang.Extensions.IAsyncEnumerable.Legacy/
+│       ├── Wolfgang.Extensions.IAsyncEnumerable.Legacy.csproj
+│       └── IAsyncEnumerableLegacyExtensions.cs
 ├── tests/                              # Test projects
 │   └── Wolfgang.Extensions.IAsyncEnumerable.Tests.Unit/
 ├── benchmarks/                         # Performance benchmarks
@@ -85,7 +88,7 @@ root/
 
 ### GitHub Integration
 - **Workflows**: `.github/workflows/pr.yaml` - Comprehensive CI/CD pipeline
-- **Issue Templates**: Bug reports (YAML) and feature requests (Markdown)
+- **Issue Templates**: Bug reports, feature requests, and maintenance tasks (all YAML)
 - **PR Template**: Structured pull request template with checklists
 - **CODEOWNERS**: Default owner `@Chris-Wolfgang`, update usernames as needed
 - **Dependabot**: Configured for NuGet packages in all project directories
@@ -93,13 +96,13 @@ root/
 ### Continuous Integration Pipeline (`.github/workflows/pr.yaml`)
 The workflow runs on pull requests to `main` branch and includes:
 
-1. **Environment**: Ubuntu Latest with .NET 8.0.x
+1. **Environment**: Multi-stage pipeline (Linux, Windows, macOS) with .NET SDKs 3.1.x through 10.0.x
 2. **Build Steps**: Checkout → Setup .NET → Restore → Build → Test → Coverage → Security
 3. **Artifacts**: Coverage reports and DevSkim results uploaded
 4. **Branch Protection**: Configured to require this workflow to pass before merging
 
 ### Branch Protection Configuration
-Branch protection rules are configured by running the local PowerShell script `scripts/Setup-BranchRuleset.ps1`. The script prompts you to choose repository settings during setup.
+Branch protection rulesets are managed in GitHub (Settings → Rules → Rulesets). The local PowerShell script `scripts/Fix-BranchRuleset.ps1` updates the ruleset's required status checks; `scripts/Setup-Labels.ps1` provisions the repo's label set.
 
 **Single-Developer Configuration (Default):**
 - No PR approvals required (you can merge your own PRs)
@@ -119,11 +122,10 @@ Branch protection rules are configured by running the local PowerShell script `s
 **Branch Protection Setup Instructions:**
 1. Install GitHub CLI (gh) from https://cli.github.com/
 2. Authenticate: `gh auth login`
-3. From PowerShell 7+ (for example, using `pwsh`), run the branch protection setup script:
+3. Create/adjust the ruleset in GitHub (Settings → Rules → Rulesets), then keep its required status checks in sync with `pr.yaml` by running:
    ```powershell
-   pwsh -File ./scripts/Setup-BranchRuleset.ps1
+   pwsh -File ./scripts/Fix-BranchRuleset.ps1
    ```
-4. When prompted by the script, choose single-developer or multi-developer settings
 
 ## Key Files and Locations
 

--- a/.gitignore
+++ b/.gitignore
@@ -433,4 +433,6 @@ nuget-packages/
 # DocFX generated files
 docfx_project/_site/
 docfx_project/obj/
+docfx_project/api/*.yml
+docfx_project/api/.manifest
 

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,4 +1,4 @@
-# BannedSymbols.txt - Async-First Enforcement for Wolfgang.Extensions.IAsyncEnumerable
+# BannedSymbols.txt - Async-First Enforcement for the Wolfgang.Extensions.IAsyncEnumerable packages
 # Format: <API Documentation ID>; <Reason/Alternative>
 # T: = Type, M: = Method, P: = Property, F: = Field
 # Task.Wait() - All overloads - Absolutely NOT allowed in async code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Code-review fixes: eager argument validation in the Legacy package's
+  wrapper methods, PublicAPI nullability annotations,
+  `Microsoft.Bcl.AsyncInterfaces` conditioned to net462/netstandard2.0
+  (net8.0+ consumers no longer pull it), `PackageRequireLicenseAcceptance`
+  removed, `PackageTags` added, and `icon.ico` no longer packed as content.
+
 ### Deprecated
 
 ### Removed
@@ -309,11 +315,12 @@ source or public-API changes.
   uploaded to the Security tab, badge added to `README.md`, 7.5 score
   floor documented in `SECURITY.md` (#247).
 
-## [0.5.2] - 2026-07-06
+## [0.5.2] - 2026-07-11
 
 ### Changed
 
 - Dependabot bump: dotnet-dependencies group (2 packages).
+
 ## [0.5.1] - 2026-06-06
 
 No public API changes. This release is a maintenance / infrastructure refresh
@@ -419,8 +426,62 @@ plus a fix for a Release-build blocker.
   without an explicit maintainer admin-bypass.
 - `persist-credentials: false` on the gitleaks / stryker checkouts.
 
+## [0.5.0] - 2026-04-27
+
+### Added
+
+- `scripts/build-pr.ps1` to replicate the PR CI checks locally, and
+  `SECURITY.md` for responsible vulnerability disclosure.
+- `netcoreapp3.1` added to the test target frameworks.
+- Release-tag-matches-csproj-version validation in `release.yaml`, and
+  `.github/workflows/*` added to protected-file detection in `pr.yaml`.
+
+### Changed
+
+- Internal core methods renamed with the `Async` suffix (VSTHRD200);
+  analyzer `PackageReference`s moved from `Directory.Build.props` to
+  individual csproj files; dependency bumps.
+
+## [0.4.0] - 2026-03-24
+
+### Added
+
+- `ForEachAsync` (sync + async action overloads), `IsEmptyAsync`,
+  `IsNullOrEmptyAsync`, and `NoneAsync` (with and without predicate)
+  extension methods.
+
+## [0.3.0] - 2026-03-24
+
+### Added
+
+- `DoAsync` extension method (sync + async action overloads).
+- Project / package icons.
+
+### Changed
+
+- Dependency bumps and documentation updates.
+
+## [0.2.0] - 2026-03-13
+
+### Changed
+
+- Workflows re-synced from `repo-template`, including the
+  `pull_request_target` → `pull_request` security fix in `pr.yaml`.
+- README / docfx link fixes and dependency bumps.
+
+## [0.1.0] - 2026-02-03
+
+### Added
+
+- Initial release: `ChunkAsync` extension method for `IAsyncEnumerable<T>`.
+
 [Unreleased]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.4...HEAD
 [0.5.4]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/Chris-Wolfgang/IAsyncEnumerable-Extensions/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ You can contribute in several ways:
 
 This project maintains **extremely high code quality standards** through multiple layers of static analysis and automated enforcement.
 
-### The 7 Analyzers
+### The 8 Analyzers
 
 All code is analyzed by these tools during build:
 
@@ -87,6 +87,10 @@ All code is analyzed by these tools during build:
    - Security vulnerability detection
    - Code smell identification
 
+8. **Microsoft.CodeAnalysis.PublicApiAnalyzers**
+   - Public-API surface tracking via `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt`
+   - Any change to the public surface fails the build until the API files are updated
+
 ### Async-First Enforcement
 
 This library **prohibits synchronous blocking calls** via `BannedSymbols.txt`. The following APIs are **banned**:
@@ -108,12 +112,12 @@ await Task.WhenAll(tasks);
 // Banned
 File.ReadAllText(path);
 stream.Read(buffer, 0, count);
-streamReader.ReadLine();
+stream.CopyTo(destination);
 
 // Required
 await File.ReadAllTextAsync(path);
 await stream.ReadAsync(buffer, 0, count);
-await streamReader.ReadLineAsync();
+await stream.CopyToAsync(destination);
 ```
 
 #### ❌ Thread Blocking

--- a/IAsyncEnumerable Extensions.slnx
+++ b/IAsyncEnumerable Extensions.slnx
@@ -2,11 +2,15 @@
   <Folder Name="/.root/">
     <File Path=".editorconfig" />
     <File Path=".gitignore" />
+    <File Path="BannedSymbols.txt" />
+    <File Path="CHANGELOG.md" />
     <File Path="CODE_OF_CONDUCT.md" />
     <File Path="CONTRIBUTING.md" />
+    <File Path="Directory.Build.props" />
     <File Path="LICENSE" />
     <File Path="README.md" />
-    <File Path="SETUP.md" />
+    <File Path="SECURITY.md" />
+    <File Path="THIRD-PARTY-NOTICES.md" />
   </Folder>
   <Folder Name="/.root/.github/">
     <File Path=".github/CODEOWNERS" />
@@ -16,13 +20,28 @@
   </Folder>
   <Folder Name="/.root/.github/ISSUE_TEMPLATE/">
     <File Path=".github/ISSUE_TEMPLATE/BUG_REPORT.yaml" />
-    <File Path=".github/ISSUE_TEMPLATE/feature_request.md" />
+    <File Path=".github/ISSUE_TEMPLATE/feature_request.yaml" />
   </Folder>
   <Folder Name="/.root/.github/workflows/">
-    <File Path=".github/workflows/create-labels.yaml" />
+    <File Path=".github/workflows/aot-smoke.yaml" />
+    <File Path=".github/workflows/benchmarks.yaml" />
+    <File Path=".github/workflows/build-all-versions.yaml" />
+    <File Path=".github/workflows/codeql.yaml" />
+    <File Path=".github/workflows/concurrency.yaml" />
+    <File Path=".github/workflows/cross-platform-differential.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
+    <File Path=".github/workflows/fuzz.yaml" />
+    <File Path=".github/workflows/license-audit.yaml" />
+    <File Path=".github/workflows/pr-benchmarks.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
+    <File Path=".github/workflows/reproducible-build.yaml" />
+    <File Path=".github/workflows/scorecard.yaml" />
+    <File Path=".github/workflows/shadow.yaml" />
+    <File Path=".github/workflows/sourcelink-verify.yaml" />
+    <File Path=".github/workflows/sourcelink.yaml" />
+    <File Path=".github/workflows/stryker.yaml" />
+    <File Path=".github/workflows/workflow-security.yaml" />
   </Folder>
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks/Wolfgang.Extensions.IAsyncEnumerable.Benchmarks.csproj" />
@@ -33,13 +52,18 @@
     <Project Path="examples/ForEachAsync.Example/ForEachAsync.Example.csproj" />
     <Project Path="examples/IsEmptyAsync.Example/IsEmptyAsync.Example.csproj" />
     <Project Path="examples/IsNullOrEmptyAsync.Example/IsNullOrEmptyAsync.Example.csproj" />
+    <Project Path="examples/Legacy.Example/Legacy.Example.csproj" />
     <Project Path="examples/NoneAsync.Example/NoneAsync.Example.csproj" />
+  </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/ShadowWorkloads/ShadowWorkloads.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj" Id="46f709fc-f4ce-4013-9254-c76bd0ab19ae" />
     <Project Path="src/Wolfgang.Extensions.IAsyncEnumerable.Legacy/Wolfgang.Extensions.IAsyncEnumerable.Legacy.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/AotSmoke/AotSmoke.csproj" />
     <Project Path="tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Fuzz/Wolfgang.Extensions.IAsyncEnumerable.Tests.Fuzz.csproj" />
     <Project Path="tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.DocExamples/Wolfgang.Extensions.IAsyncEnumerable.Tests.DocExamples.csproj" />
     <Project Path="tests/Wolfgang.Extensions.IAsyncEnumerable.Tests.Concurrency/Wolfgang.Extensions.IAsyncEnumerable.Tests.Concurrency.csproj" />

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,4 +75,4 @@ Facts a maintainer would need at 2am if the release identity is compromised. Gen
 - **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/IAsyncEnumerable-Extensions`).
 - **Owner**: @Chris-Wolfgang.
 - **Downstream consumers**: none known within the Wolfgang.* fleet; unknown external consumers may exist on nuget.org.
-- **Package coordinates for unlisting**: `Wolfgang.Extensions.IAsyncEnumerable` — https://www.nuget.org/packages/Wolfgang.Extensions.IAsyncEnumerable/.
+- **Package coordinates for unlisting**: `Wolfgang.Extensions.IAsyncEnumerable` — https://www.nuget.org/packages/Wolfgang.Extensions.IAsyncEnumerable/; `Wolfgang.Extensions.IAsyncEnumerable.Legacy` — https://www.nuget.org/packages/Wolfgang.Extensions.IAsyncEnumerable.Legacy/.

--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -5,7 +5,7 @@
       "src": [
         {
           "files": [
-            "src/**/*.csproj"
+            "src/Wolfgang.Extensions.IAsyncEnumerable/*.csproj"
           ],
           "src": "../"
         }
@@ -13,6 +13,22 @@
       "dest": "api",
       "properties": {
         "TargetFramework": "net8.0"
+      },
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    },
+    {
+      "src": [
+        {
+          "files": [
+            "src/Wolfgang.Extensions.IAsyncEnumerable.Legacy/*.csproj"
+          ],
+          "src": "../"
+        }
+      ],
+      "dest": "api",
+      "properties": {
+        "TargetFramework": "netstandard2.0"
       },
       "disableGitFeatures": false,
       "disableDefaultFilter": false

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -105,10 +105,10 @@ public record DataRecord
 ### Method Signature
 
 ```csharp
-public static async IAsyncEnumerable<ICollection<T>> ChunkAsync<T>(
+public static IAsyncEnumerable<ICollection<T>> ChunkAsync<T>(
     this IAsyncEnumerable<T> source,
     int maxChunkSize,
-    [EnumeratorCancellation] CancellationToken token = default)
+    CancellationToken token = default)
 ```
 
 ### Parameters

--- a/docfx_project/docs/introduction.md
+++ b/docfx_project/docs/introduction.md
@@ -14,7 +14,7 @@ This library provides:
 - **High Performance**: Optimized implementations with minimal allocations
 - **Comprehensive Test Coverage**: Extensive unit tests ensure reliability
 - **Multi-Framework Support**: Works with .NET Framework 4.6.2, .NET Standard 2.0, .NET 8.0, and .NET 10.0
-- **Strict Code Quality**: Enforced through 7 specialized analyzers and async-first patterns
+- **Strict Code Quality**: Enforced through 8 specialized analyzers and async-first patterns
 
 ## Key Features
 
@@ -104,7 +104,7 @@ This library is built with an **async-first philosophy**:
 
 The library maintains exceptional code quality through:
 
-1. **7 Specialized Analyzers**: Including AsyncFixer, Roslynator, and SonarAnalyzer
+1. **8 Specialized Analyzers**: Including AsyncFixer, Roslynator, and SonarAnalyzer
 2. **Banned API Enforcement**: Prevents usage of synchronous and obsolete APIs
 3. **Comprehensive Testing**: High test coverage with both unit and integration tests
 4. **Strict Formatting**: Enforced through `.editorconfig` and `dotnet format`

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -41,22 +41,17 @@ await foreach (var chunk in asyncStream.ChunkAsync(maxChunkSize: 100, token: can
 
 ### Current Extension Methods
 
+All 9 methods live on `IAsyncEnumerableExtensions` in the `Wolfgang.Extensions.IAsyncEnumerable` namespace.
+
 #### **`ChunkAsync<T>`**
-Splits an `IAsyncEnumerable<T>` into fixed-size chunks for batch processing.
+Splits an `IAsyncEnumerable<T>` into fixed-size chunks for batch processing. The last chunk may be smaller than `maxChunkSize`.
 
 ```csharp
-public static async IAsyncEnumerable<ICollection<T>> ChunkAsync<T>(
+public static IAsyncEnumerable<ICollection<T>> ChunkAsync<T>(
     this IAsyncEnumerable<T> source,
     int maxChunkSize,
     CancellationToken token = default)
 ```
-
-**Parameters:**
-- `source` - The source async enumerable to chunk
-- `maxChunkSize` - Maximum size of each chunk (must be > 0)
-- `token` - Optional cancellation token
-
-**Returns:** An async enumerable of collections, where each collection contains up to `maxChunkSize` elements.
 
 **Example:**
 ```csharp
@@ -69,47 +64,24 @@ await foreach (var batch in numbers.ChunkAsync(50))
 ```
 
 #### **`DoAsync<T>` (Synchronous action)**
-Executes a synchronous side-effect action on each element without transforming the elements. The original items are yielded unchanged.
+Executes a synchronous side-effect action on each element without transforming the elements. The original items are yielded unchanged — ideal for logging or metrics inside a pipeline.
 
 ```csharp
-public static async IAsyncEnumerable<T> DoAsync<T>(
+public static IAsyncEnumerable<T> DoAsync<T>(
     this IAsyncEnumerable<T> source,
     Action<T> action,
     CancellationToken token = default)
-```
-
-**Parameters:**
-- `source` - The source async enumerable
-- `action` - The synchronous action to execute on each element
-- `token` - Optional cancellation token
-
-**Returns:** An async enumerable that yields the original elements after executing the action.
-
-**Example:**
-```csharp
-var numbers = GetAsyncNumbers(); // IAsyncEnumerable<int>
-await foreach (var item in numbers.DoAsync(x => Console.WriteLine($"Processing: {x}")))
-{
-    // item is unchanged — DoAsync is a pass-through
-}
 ```
 
 #### **`DoAsync<T>` (Asynchronous action)**
 Executes an asynchronous side-effect action on each element without transforming the elements.
 
 ```csharp
-public static async IAsyncEnumerable<T> DoAsync<T>(
+public static IAsyncEnumerable<T> DoAsync<T>(
     this IAsyncEnumerable<T> source,
     Func<T, Task> action,
     CancellationToken token = default)
 ```
-
-**Parameters:**
-- `source` - The source async enumerable
-- `action` - The asynchronous action to execute on each element
-- `token` - Optional cancellation token
-
-**Returns:** An async enumerable that yields the original elements after executing the action.
 
 **Example:**
 ```csharp
@@ -120,6 +92,94 @@ await foreach (var batch in source
 {
     await ProcessBatchAsync(batch);
 }
+```
+
+#### **`ForEachAsync<T>` (Synchronous action)**
+Terminal operation that consumes the sequence, executing a synchronous action on each element.
+
+```csharp
+public static Task ForEachAsync<T>(
+    this IAsyncEnumerable<T> source,
+    Action<T> action,
+    CancellationToken token = default)
+```
+
+#### **`ForEachAsync<T>` (Asynchronous action)**
+Terminal operation that consumes the sequence, awaiting an asynchronous action for each element.
+
+```csharp
+public static Task ForEachAsync<T>(
+    this IAsyncEnumerable<T> source,
+    Func<T, Task> action,
+    CancellationToken token = default)
+```
+
+**Example:**
+```csharp
+await source.ForEachAsync(x => Console.WriteLine($"Item: {x}"));
+await source.ForEachAsync(async x => await logger.LogAsync($"Item: {x}"));
+```
+
+#### **`IsEmptyAsync<T>`**
+Determines whether the sequence contains no elements. Stops after checking the first element.
+
+```csharp
+public static Task<bool> IsEmptyAsync<T>(
+    this IAsyncEnumerable<T> source,
+    CancellationToken token = default)
+```
+
+#### **`IsNullOrEmptyAsync<T>`**
+Determines whether the sequence is `null` or contains no elements. The only method that accepts a `null` receiver.
+
+```csharp
+public static Task<bool> IsNullOrEmptyAsync<T>(
+    this IAsyncEnumerable<T>? source,
+    CancellationToken token = default)
+```
+
+#### **`NoneAsync<T>` (No predicate)**
+Determines whether the sequence contains no elements — the inverse of `Any`.
+
+```csharp
+public static Task<bool> NoneAsync<T>(
+    this IAsyncEnumerable<T> source,
+    CancellationToken token = default)
+```
+
+#### **`NoneAsync<T>` (Predicate)**
+Determines whether no element satisfies a condition. Short-circuits on the first match.
+
+```csharp
+public static Task<bool> NoneAsync<T>(
+    this IAsyncEnumerable<T> source,
+    Func<T, bool> predicate,
+    CancellationToken token = default)
+```
+
+**Example:**
+```csharp
+if (await source.NoneAsync(x => x.IsExpired))
+{
+    Console.WriteLine("No expired items.");
+}
+```
+
+### Legacy Terminal Operators (`Wolfgang.Extensions.IAsyncEnumerable.Legacy`)
+
+A companion package for consumers on **net462 / netstandard2.0**, where the BCL's `System.Linq.AsyncEnumerable` is not available. It provides 6 terminal operators on `IAsyncEnumerableLegacyExtensions` (same `Wolfgang.Extensions.IAsyncEnumerable` namespace):
+
+- `CountAsync<T>` — counts the elements in the sequence
+- `AnyAsync<T>` — determines whether the sequence contains any elements
+- `AnyAsync<T>(predicate)` — determines whether any element satisfies a condition
+- `FirstAsync<T>` — returns the first element (throws if empty)
+- `FirstOrDefaultAsync<T>` — returns the first element, or `default(T)` if empty
+- `ToListAsync<T>` — materializes the sequence into a `List<T>`
+
+The package targets **only** net462 and netstandard2.0, so there is no ambiguous-call risk with `System.Linq.AsyncEnumerable` on net8.0+ — it simply doesn't apply there.
+
+```bash
+dotnet add package Wolfgang.Extensions.IAsyncEnumerable.Legacy
 ```
 
 ---
@@ -136,7 +196,7 @@ This library supports multiple .NET versions:
 
 ## 🔍 Code Quality & Static Analysis
 
-This project enforces **strict code quality standards** through **7 specialized analyzers** and custom async-first rules:
+This project enforces **strict code quality standards** through **8 specialized analyzers** and custom async-first rules:
 
 ### Analyzers in Use
 
@@ -187,7 +247,7 @@ dotnet build --configuration Release
 dotnet test --configuration Release
 
 # Run code formatting (PowerShell Core)
-pwsh ./format.ps1
+pwsh ./scripts/format.ps1
 ```
 
 ### Code Formatting
@@ -217,7 +277,7 @@ cd docfx_project
 docfx metadata  # Extract API metadata from source code
 docfx build     # Build HTML documentation
 
-# Documentation is generated in the docs/ folder at the repository root
+# Documentation is generated in docfx_project/_site/
 ```
 
 The documentation is automatically built and deployed to GitHub Pages when changes are pushed to the `main` branch.
@@ -233,7 +293,7 @@ docfx build --serve
 
 **Documentation Structure:**
 - `docfx_project/` - DocFX configuration and source files
-- `docs/` - Generated HTML documentation (published to GitHub Pages)
+- `docfx_project/_site/` - Generated HTML documentation (published to GitHub Pages)
 - `docfx_project/index.md` - Main landing page content
 - `docfx_project/docs/` - Additional documentation articles
 - `docfx_project/api/` - Auto-generated API reference YAML files

--- a/docs/ALLOCATION-POLICY.md
+++ b/docs/ALLOCATION-POLICY.md
@@ -20,6 +20,20 @@ left to check isn't worth the maintenance weight. This is the documented
 method is intended to be zero-alloc (snapshot doc explaining why instead
 of half-implemented enforcement)."* This file is that snapshot.
 
+## The Legacy package (`Wolfgang.Extensions.IAsyncEnumerable.Legacy`)
+
+The same policy applies to `IAsyncEnumerableLegacyExtensions`. All 6 terminal
+operators (`CountAsync`, `AnyAsync` × 2, `FirstAsync`, `FirstOrDefaultAsync`,
+`ToListAsync`) compile to `async` state machines, and the package targets
+only net462/netstandard2.0 — TFMs with none of the cached-task /
+`IValueTaskSource` optimizations newer runtimes use — so none of them is
+zero-alloc, by design. `ToListAsync` additionally allocates the returned
+`List<T>`; that allocation is the method's purpose. Beyond the state machine
+and the enumerator the source itself provides, there are no other
+per-element allocations, and the eager-validation wrapper methods allocate
+nothing on the happy path (validation happens before any state machine is
+created).
+
 ## What's already in place instead
 
 `[MemoryDiagnoser]` is enabled on every `BenchmarkDotNet` benchmark class

--- a/docs/CULTURE-INVARIANCE.md
+++ b/docs/CULTURE-INVARIANCE.md
@@ -10,6 +10,13 @@ string comparison, no numeric parsing. Every one of the 9 public methods
 structurally: enumerate the source, invoke a caller-supplied delegate,
 batch into arrays, count. None of that touches culture.
 
+The same holds for the Legacy package's 6 methods on
+`IAsyncEnumerableLegacyExtensions` (`CountAsync`, `AnyAsync` × 2,
+`FirstAsync`, `FirstOrDefaultAsync`, `ToListAsync`): they perform no string
+formatting or parsing at all. The only string in the package is
+`FirstAsync`'s "Sequence contains no elements" exception message, a
+culture-invariant literal.
+
 ## Allowlist of intentionally culture-sensitive methods
 
 **None.** Every public method is culture-invariant by construction, not by

--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -15,25 +15,33 @@ The release workflow triggers when you **publish a GitHub Release** and implemen
 
 Complete the following one-time setup so that the workflow can publish releases:
 
-### Add NuGet API Key Secret
+### Configure NuGet Trusted Publishing (OIDC)
 
-**Location:** Settings → Secrets and variables → Actions → New repository secret
+Publishing uses [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) via `NuGet/login@v1` in `release.yaml`. There is **no long-lived `NUGET_API_KEY` repository secret** — at release time the workflow exchanges its GitHub OIDC token for an ephemeral (~1 hour) push key, so there is no standing credential to rotate or leak.
 
-1. Click **"New repository secret"**
-2. **Name:** `NUGET_API_KEY`
-3. **Value:** Your NuGet.org API key
-   - Get your key from [NuGet.org Account → API Keys](https://www.nuget.org/account/apikeys)
-   - Recommended scopes: **Push new packages and package versions**
-   - Set expiration date (recommended: 1 year)
-4. Click **"Add secret"**
+**Location:** nuget.org → account `Chris-Wolfgang` → Manage → Trusted Publishing
 
-**What this does:** Allows the workflow to authenticate with NuGet.org and publish packages. The workflow validates this secret exists before attempting to publish.
+Create one policy **per package ID** (this repo ships two packages, so it needs two policies):
+
+- `Wolfgang.Extensions.IAsyncEnumerable`
+- `Wolfgang.Extensions.IAsyncEnumerable.Legacy`
+
+Each policy's fields:
+
+| Field | Value |
+|-------|-------|
+| Repository owner | `Chris-Wolfgang` |
+| Repository | `IAsyncEnumerable-Extensions` |
+| Workflow file | `release.yaml` |
+| Environment | *(blank)* |
+
+**What this does:** Authorizes this repository's `release.yaml` workflow — and only it — to push the named package. This is a one-time setup per package; nothing needs periodic renewal.
 
 ### Verify Branch Protection Rules
 
 **Location:** Settings → Branches → main (or Settings → Rules → Rulesets)
 
-> **Note:** Repos created from `repo-template` ship with `scripts/Setup-BranchRuleset.ps1`, which configures branch protection interactively (option `[1]` for single-developer mode, `[2]` for multi-developer mode). The script may not be present in older repos — if it is missing, configure the equivalent settings manually using the checklist below.
+> **Note:** This repo's `scripts/Fix-BranchRuleset.ps1` can update the ruleset's required status checks. For initial ruleset creation, configure the settings manually using the checklist below (Settings → Rules → Rulesets).
 
 Ensure the following settings are enabled:
 
@@ -83,9 +91,9 @@ The workflow triggers automatically when the release is published.
    - ✅ Auto-passes if packages are valid
 
 3. **Job 3: publish-nuget** (1-2 minutes)
-   - Validates NUGET_API_KEY secret
+   - Exchanges the workflow's OIDC token for an ephemeral (~1h) push key via `NuGet/login@v1`
    - Publishes packages to NuGet.org automatically
-   - ✅ Auto-completes if secret is valid
+   - ✅ Auto-completes if the Trusted Publishing policies are configured
 
 ### Monitoring the Workflow
 
@@ -95,13 +103,13 @@ The workflow triggers automatically when the release is published.
 
 ## Troubleshooting
 
-### "NUGET_API_KEY secret not configured" Error
+### OIDC Login / Push Fails in `publish-nuget`
 
-**Problem:** The `publish-nuget` job fails with secret validation error.
+**Problem:** The `NuGet/login@v1` step (or the subsequent push) fails.
 
-**Solution:**
-1. Verify the secret name is exactly `NUGET_API_KEY` (case-sensitive)
-2. Re-add the secret in Settings → Secrets → Actions
+**Solution:** A failed OIDC exchange means the Trusted Publishing policy is missing or misconfigured on nuget.org.
+1. Check nuget.org → account `Chris-Wolfgang` → Manage → Trusted Publishing
+2. Verify a policy exists for **each** package ID (`Wolfgang.Extensions.IAsyncEnumerable` and `Wolfgang.Extensions.IAsyncEnumerable.Legacy`) with owner `Chris-Wolfgang`, repository `IAsyncEnumerable-Extensions`, workflow file `release.yaml`, and a blank environment
 3. Re-run the workflow from the Actions tab (do not re-publish the release)
 
 ### Tests Fail on Specific Framework
@@ -189,7 +197,7 @@ Before creating a production GitHub Release (e.g., `v1.0.0`):
 ┌─────────────────────────────────────────────────────────────┐
 │  Job 3: publish-nuget (Windows)                             │
 │  • Download packages                                        │
-│  • Validate NUGET_API_KEY                                   │
+│  • OIDC login (NuGet/login@v1, ephemeral push key)          │
 │  • Publish to NuGet.org automatically                       │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -202,7 +210,7 @@ Before creating a production GitHub Release (e.g., `v1.0.0`):
 | **Code Coverage** | Not enforced | 90% threshold enforced |
 | **Package Validation** | None | Smoke test installation |
 | **Deployment** | Incomplete publish script | Automatic publishing after validation |
-| **Secret Validation** | None | Validates before publishing |
+| **Credentials** | Long-lived API key secret | Trusted Publishing (OIDC), ephemeral push key |
 | **GitHub Releases** | Not used as trigger | Workflow triggered by published release |
 | **Build Efficiency** | Duplicate builds in each job | Build once per job with dependencies |
 | **Test Logging** | No logger parameter | Console logging with verbosity |

--- a/docs/SOURCELINK-VERIFICATION.md
+++ b/docs/SOURCELINK-VERIFICATION.md
@@ -13,7 +13,11 @@ no headless way to simulate a developer's keypress and observe whether the
 debugger resolved real source vs. decompiled assembly. So this workflow
 verifies every *mechanical prerequisite* step-into depends on instead:
 
-1. Build the library (Release, net10.0).
+1. Build the library (Release). The workflow matrixes over both shipped
+   packages: `Wolfgang.Extensions.IAsyncEnumerable` at net10.0 and
+   `Wolfgang.Extensions.IAsyncEnumerable.Legacy` at netstandard2.0 (its
+   net462 slot doesn't build reliably on ubuntu-latest, and the
+   netstandard2.0 PDB embeds the same SourceLink metadata).
 2. Use the [`sourcelink`](https://github.com/dotnet/sourcelink) dotnet tool's
    `print-urls` command to read the PDB's embedded SourceLink JSON and list
    every source file's mapped URL (a commit-pinned

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -82,7 +82,7 @@ All checkout steps include `persist-credentials: false` to prevent the checkout 
 
 ```yaml
 - name: Checkout code
-  uses: actions/checkout@v6
+  uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
   with:
     ref: refs/pull/${{ github.event.pull_request.number }}/head
     persist-credentials: false

--- a/examples/Legacy.Example/Legacy.Example.csproj
+++ b/examples/Legacy.Example/Legacy.Example.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net462</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IAsyncEnumerable.Legacy\Wolfgang.Extensions.IAsyncEnumerable.Legacy.csproj" />
+	</ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/examples/Legacy.Example/Program.cs
+++ b/examples/Legacy.Example/Program.cs
@@ -1,0 +1,56 @@
+// This example deliberately targets net462: Wolfgang.Extensions.IAsyncEnumerable.Legacy
+// exists precisely for TFMs (net462 / netstandard2.0) where the BCL's
+// System.Linq.AsyncEnumerable is not available. On net8.0+ you would use the
+// BCL's built-in operators instead — the Legacy package doesn't apply there.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Wolfgang.Extensions.IAsyncEnumerable;
+
+namespace LegacyExample
+{
+    internal static class Program
+    {
+        private static async Task Main()
+        {
+            Console.WriteLine("=== Wolfgang.Extensions.IAsyncEnumerable.Legacy Example ===");
+            Console.WriteLine();
+
+            // CountAsync — count the elements in an async sequence
+            var count = await GenerateNumbers(5).CountAsync();
+            Console.WriteLine($"CountAsync over 5 numbers: {count}");
+
+            // AnyAsync() — does the sequence contain any elements?
+            Console.WriteLine($"AnyAsync on populated stream: {await GenerateNumbers(5).AnyAsync()}");
+            Console.WriteLine($"AnyAsync on empty stream: {await GenerateNumbers(0).AnyAsync()}");
+
+            // AnyAsync(predicate) — does any element match? Short-circuits on first match.
+            Console.WriteLine($"Any divisible by 3: {await GenerateNumbers(10).AnyAsync(n => n % 3 == 0)}");
+            Console.WriteLine($"Any greater than 100: {await GenerateNumbers(10).AnyAsync(n => n > 100)}");
+
+            // FirstAsync — first element (throws InvalidOperationException if empty)
+            var first = await GenerateNumbers(5).FirstAsync();
+            Console.WriteLine($"FirstAsync: {first}");
+
+            // FirstOrDefaultAsync — first element, or default(T) when the sequence is empty
+            var firstOrDefault = await GenerateNumbers(0).FirstOrDefaultAsync();
+            Console.WriteLine($"FirstOrDefaultAsync on empty stream: {firstOrDefault}");
+
+            // ToListAsync — materialize the whole sequence into a List<T>
+            var list = await GenerateNumbers(5).ToListAsync();
+            Console.WriteLine($"ToListAsync: [{string.Join(", ", list)}]");
+        }
+
+
+
+        private static async IAsyncEnumerable<int> GenerateNumbers(int count)
+        {
+            for (var i = 1; i <= count; i++)
+            {
+                await Task.Yield();
+                yield return i;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part 3 of 4 of the code-review fix stack (stacks on the test-fixes PR).

## Fixes
**Release-pipeline blockers**
- **docfx.json**: metadata forced `TargetFramework: net8.0` on `src/**` — the Legacy package (net462/ns2.0 only) was silently dropped from the generated API docs, and `verify-docs-build` gates `publish-nuget`. Now two metadata entries (main @ net8.0, Legacy @ netstandard2.0)
- **docs/RELEASE-WORKFLOW-SETUP.md**: was still an end-to-end `NUGET_API_KEY` secret guide; rewritten for Trusted Publishing (one nuget.org policy **per package ID**, ephemeral OIDC push key, failure modes)

**Repo hygiene**
- `.gitignore`: docfx metadata output (`api/*.yml`, `api/.manifest`) ignored file-shaped (tracked `api/README.md`/`index.md` unaffected) — 4 generated files were polluting `git status`
- `.slnx`: 3 dead file refs removed; **AotSmoke + ShadowWorkloads projects added** (missing); full 19-file workflow list (was a stale 4); root docs/config files added

**Docs vs code**
- CHANGELOG: 0.5.2 date fixed (tag created 07-11); v0.1.0–v0.5.0 backfilled from git history with footer links
- SECURITY.md incident appendix lists both packages' coordinates
- Analyzer count 7 → 8 everywhere (PublicApiAnalyzers was missing from CONTRIBUTING + docfx pages); CONTRIBUTING's banned-API example now uses a symbol actually in BannedSymbols.txt
- docfx index documents all 9 main methods + Legacy 6 (was 3 of 9); wrong paths/claims fixed; wrapper signatures no longer marked `async`
- ALLOCATION-POLICY / CULTURE-INVARIANCE / SOURCELINK-VERIFICATION / WORKFLOW_SECURITY / BannedSymbols header / copilot-instructions updated for the two-package reality

**New**: `examples/Legacy.Example` — net462-only console example for all 6 terminal operators (deliberately targeting the TFM the package exists for).

## Test plan
- [x] Solution Release build 0 errors (incl. the newly-added AotSmoke/ShadowWorkloads/Legacy.Example)
- [x] docfx.json valid JSON; gitignore verified effective

🤖 Generated with [Claude Code](https://claude.com/claude-code)