### PR TITLE
Generalize BannedSymbols.txt header (protected-file split for v0.6.0)

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,4 +1,4 @@
-# BannedSymbols.txt - Async-First Enforcement for Wolfgang.Extensions.IAsyncEnumerable
+# BannedSymbols.txt - Async-First Enforcement for the Wolfgang.Extensions.IAsyncEnumerable packages
 # Format: <API Documentation ID>; <Reason/Alternative>
 # T: = Type, M: = Method, P: = Property, F: = Field
 # Task.Wait() - All overloads - Absolutely NOT allowed in async code


### PR DESCRIPTION
One-line comment change: the BannedSymbols.txt header named only the single original package; the repo now ships two. Split out of the v0.6.0 release delta (the only protected file in it) so the release PR merges through the full ruleset with zero bypass.

**Needs an admin-bypass merge** — the "Detect protected configuration file changes" check fails by design on any PR touching BannedSymbols.txt. The diff is one comment line; easy to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)