### PR TITLE
DevSkim gate fixes (protected-file split for v0.6.0)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,7 +83,7 @@ jobs:
         # Pinned to a specific version with SHA256 checksum verification for supply-chain safety
         run: |
           GITLEAKS_VERSION="8.24.0"
-          GITLEAKS_SHA256="cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4"
+          GITLEAKS_SHA256="cb49b7de5ee986510fe8666ca0273a6cc15eb82571f2f14832c9e8920751f3a4" # DevSkim: ignore DS173237 - integrity checksum, not a secret
           mkdir -p "$HOME/.local/bin"
           TARBALL="$(mktemp)"
           curl -sSfL -o "$TARBALL" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
@@ -1685,7 +1685,7 @@ jobs:
             --file-format text \
             --output-file devskim-results.txt \
             --ignore-rule-ids DS176209 \
-            --ignore-globs "**/api/**,**/CoverageReport/**,**/TestResults/**"
+            --ignore-globs "**/api/**,**/CoverageReport/**,**/TestResults/**,**/_site/**"
 
           # Second pass in SARIF purely for the severity gate below. The text
           # output above stays for human-readable display; gating on it with a
@@ -1698,7 +1698,7 @@ jobs:
             --file-format sarif \
             --output-file devskim-results.sarif \
             --ignore-rule-ids DS176209 \
-            --ignore-globs "**/api/**,**/CoverageReport/**,**/TestResults/**"
+            --ignore-globs "**/api/**,**/CoverageReport/**,**/TestResults/**,**/_site/**"
 
       - name: Display security scan results
         if: always()
@@ -1728,5 +1728,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: devskim-results
-          path: devskim-results.txt
+          path: |
+            devskim-results.txt
+            devskim-results.sarif
           if-no-files-found: warn


### PR DESCRIPTION
Fixes the one red check on release PR #335. The new SARIF-severity DevSkim gate (from #326) surfaced 5 latent error-level findings the old substring-grep gate provably never saw — all false positives:

- `pr.yaml:86` — DS173237 flags the gitleaks **SHA256 integrity checksum** as a "token in source". Suppressed same-line with rationale (this PR).
- `scripts/build-pr.ps1` ×2 + `DeepBehaviorTests.cs` ×2 — same rule on the checksum table + weak-RNG on deterministic test data. Suppressed on vNext directly (not protected files, land with #335).

Also in this PR while touching the DevSkim job: `**/_site/**` added to ignore-globs (untracked docfx output noise on local runs) and the SARIF now uploads with the artifact so future gate failures are diagnosable.

**Needs an admin-bypass merge** (touches pr.yaml). One suppression comment + two job-config lines; easy to eyeball.

After this merges I'll reconcile main→vNext, push the two non-protected suppressions, and #335 should go fully green — every other check already passed (Stage 1/2/3, InspectCode, ApiCompat, Stryker, CodeQL, benchmarks, AOT, SourceLink, licenses, gitleaks, Detect .NET Projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)