### PR TITLE
chore: advance PackageValidation baselines to 0.6.0

### DIFF
--- a/src/Wolfgang.Extensions.IAsyncEnumerable.Legacy/Wolfgang.Extensions.IAsyncEnumerable.Legacy.csproj
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable.Legacy/Wolfgang.Extensions.IAsyncEnumerable.Legacy.csproj
@@ -22,6 +22,7 @@
 		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<EnablePackageValidation>True</EnablePackageValidation>
+		<PackageValidationBaselineVersion>0.6.0</PackageValidationBaselineVersion>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags>async;iasyncenumerable;async-enumerable;async-streams;extensions;linq;terminal-operators;count;any;first;tolist;net462;netstandard20;polyfill</PackageTags>
 		<PackageIcon>icon_128x128.png</PackageIcon>

--- a/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IAsyncEnumerable/Wolfgang.Extensions.IAsyncEnumerable.csproj
@@ -22,7 +22,7 @@
 		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<EnablePackageValidation>True</EnablePackageValidation>
-		<PackageValidationBaselineVersion>0.5.4</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>0.6.0</PackageValidationBaselineVersion>
 		<SignAssembly>False</SignAssembly>
 		<PackageTags>async;iasyncenumerable;async-enumerable;async-streams;extensions;linq;chunk;batch;foreach;dotnet;netstandard</PackageTags>
 		<PackageIcon>icon_128x128.png</PackageIcon>


### PR DESCRIPTION
Post-release baseline bump for v0.6.0 (tracked in #336):

- Main package: `PackageValidationBaselineVersion` 0.5.4 → 0.6.0
- Legacy package: gains its **first** baseline (0.6.0 — its first published version), so the next release gets ABI protection from day one

Both package IDs confirmed indexed on the flatcontainer CDN before opening this; `dotnet pack` verified locally against the live baselines with zero breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)