### PR TITLE
ci(release): replace softprops/action-gh-release with gh release upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -868,13 +868,16 @@ jobs:
         run: zip -r release-coverage.zip ./release-coverage
 
       - name: Attach artifacts to release
-        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64  # v3.0.3
-        with:
-          tag_name: ${{ github.event.release.tag_name }}
-          files: |
-            ./nuget-packages/*.nupkg
-            ./nuget-packages/*.snupkg
-            ./nuget-packages/*.bom.json
-            ./nuget-packages/reproducible-build-manifest.json
-            release-coverage.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          gh release upload "$TAG_NAME" \
+            ./nuget-packages/*.nupkg \
+            ./nuget-packages/*.snupkg \
+            ./nuget-packages/*.bom.json \
+            ./nuget-packages/reproducible-build-manifest.json \
+            release-coverage.zip \
+            --clobber
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -873,6 +873,10 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
+          # SBOM generation continues on per-project failure, so *.bom.json
+          # can legitimately be absent — nullglob drops the pattern instead
+          # of passing gh the literal unmatched glob string.
+          shopt -s nullglob
           gh release upload "$TAG_NAME" \
             ./nuget-packages/*.nupkg \
             ./nuget-packages/*.snupkg \


### PR DESCRIPTION
## Summary

Closes #341. Replaces `softprops/action-gh-release` with a `gh release upload` script step in the `update-release-artifacts` job — zizmor flags the action as `superfluous-actions` since it does nothing `gh` (pre-installed on every GitHub-hosted runner) doesn't already do natively for this use case (attaching files to an already-existing release, not creating one).

## Change

Same file set attached as before: `*.nupkg`, `*.snupkg`, `*.bom.json`, `reproducible-build-manifest.json`, `release-coverage.zip`. `--clobber` matches the action's implicit overwrite-on-republish behavior. The job already has `contents: write`, and runs on `ubuntu-latest` (bash is the default shell there, no `shell:` override needed).

## Why this couldn't be verified in CI

`release.yaml` only triggers on `release: published` — a normal PR build can't exercise it. I validated:
- YAML parses cleanly (`yaml.safe_load`).
- The job's `runs-on`/shell/permissions context (confirmed `ubuntu-latest` + `contents: write` already present).
- The file-glob assumptions (`Directory.Build.props` sets `IncludeSymbols=true` / `SymbolPackageFormat=snupkg` fleet-wide, and `.bom.json`/manifest are produced earlier in the same workflow's `pack-and-validate` job) — so none of the globs should come up empty on a real release.

Given that, **please validate on the next real release** (or a controlled test tag) before assuming this is fully proven — this PR only gets it to "should work," not "verified working."

## Note

This touches `.github/workflows/release.yaml`, a protected file — expect this to trip the `Detect .NET Projects` guard and need an admin-bypass merge, per fleet convention. Same fix as [D20-Dice#296](https://github.com/Chris-Wolfgang/D20-Dice/pull/296).
